### PR TITLE
v0.7 穩健性:headless 記憶體上限、cache exit code、MCP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "rustbrowser"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbrowser"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 description = "Token-lean web content fetcher for LLMs — distills pages to clean Markdown."

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ CI 會執行 fmt、clippy、build、test、release build,並檢查 release binar
 - ✅ **v0.4** — headless 自動 fallback(auto 偵測 JS 動態站)+ 連結/表格結構化擷取
 - ✅ **v0.5** — 全頁連結擷取 · headless 等待控制(`--js-wait` / CDP `--js-wait-for`)· release 發布自動化
 - ✅ **v0.6(強化)** — wiremock 端到端整合測試 · `--allow-local` loopback 豁免 · `cache` 維護子命令 · headless sandbox 預設開啟 + DOM 上限
+- ✅ **v0.7(穩健性)** — headless DOM cap 改串流讀取真正限制記憶體 · `cache` 失敗回傳非零 exit code · MCP transport 明確處理斷線/錯誤(乾淨關閉、診斷只進 stderr)
 
 ## 技術棧
 

--- a/src/bin/rustbrowser-mcp.rs
+++ b/src/bin/rustbrowser-mcp.rs
@@ -5,14 +5,16 @@
 //! Transport is stdio: the MCP protocol speaks over stdout, so NOTHING may be
 //! printed to stdout except protocol frames. All diagnostics go to stderr.
 
+use std::process::ExitCode;
 use std::time::Duration;
 
-use anyhow::Result;
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{ServerCapabilities, ServerInfo},
-    schemars, tool, tool_handler, tool_router,
+    schemars,
+    service::QuitReason,
+    tool, tool_handler, tool_router,
     transport::stdio,
 };
 use serde::Deserialize;
@@ -330,9 +332,44 @@ impl ServerHandler for RustBrowserServer {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
-    // stdout is reserved for the MCP protocol; never print to it.
-    let service = RustBrowserServer::new().serve(stdio()).await?;
-    service.waiting().await?;
-    Ok(())
+async fn main() -> ExitCode {
+    // stdout carries the MCP protocol frames; every diagnostic goes to stderr so
+    // it can never corrupt the stream.
+    eprintln!("rustbrowser-mcp: starting on stdio transport");
+
+    let service = match RustBrowserServer::new().serve(stdio()).await {
+        Ok(service) => service,
+        Err(e) => {
+            eprintln!("rustbrowser-mcp: failed to start MCP service: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Run until the client disconnects (stdin EOF) or the service is cancelled —
+    // both are clean shutdowns. Only a panicked/aborted service task or a
+    // transport error is a genuine failure worth a non-zero exit.
+    match service.waiting().await {
+        Ok(QuitReason::Closed) => {
+            eprintln!("rustbrowser-mcp: client disconnected, shutting down");
+            ExitCode::SUCCESS
+        }
+        Ok(QuitReason::Cancelled) => {
+            eprintln!("rustbrowser-mcp: service cancelled, shutting down");
+            ExitCode::SUCCESS
+        }
+        Ok(QuitReason::JoinError(e)) => {
+            eprintln!("rustbrowser-mcp: service task failed: {e}");
+            ExitCode::FAILURE
+        }
+        Ok(other) => {
+            // Future rmcp versions may add shutdown reasons; treat an unknown one
+            // as a clean stop, but log it so the cause is visible.
+            eprintln!("rustbrowser-mcp: shutting down ({other:?})");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("rustbrowser-mcp: transport error while serving: {e}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/src/bin/rustbrowser-mcp.rs
+++ b/src/bin/rustbrowser-mcp.rs
@@ -340,6 +340,12 @@ async fn main() -> ExitCode {
     let service = match RustBrowserServer::new().serve(stdio()).await {
         Ok(service) => service,
         Err(e) => {
+            if is_clean_startup_disconnect(&e) {
+                eprintln!(
+                    "rustbrowser-mcp: client disconnected before initialization, shutting down"
+                );
+                return ExitCode::SUCCESS;
+            }
             eprintln!("rustbrowser-mcp: failed to start MCP service: {e}");
             return ExitCode::FAILURE;
         }
@@ -371,5 +377,37 @@ async fn main() -> ExitCode {
             eprintln!("rustbrowser-mcp: transport error while serving: {e}");
             ExitCode::FAILURE
         }
+    }
+}
+
+fn is_clean_startup_disconnect(e: &impl std::fmt::Display) -> bool {
+    let msg = e.to_string().to_ascii_lowercase();
+    msg.contains("connection closed") && msg.contains("initialize request")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DisplayErr(&'static str);
+
+    impl std::fmt::Display for DisplayErr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    #[test]
+    fn startup_initialize_eof_is_clean_disconnect() {
+        assert!(is_clean_startup_disconnect(&DisplayErr(
+            "connection closed: initialize request"
+        )));
+    }
+
+    #[test]
+    fn unrelated_startup_error_is_not_clean_disconnect() {
+        assert!(!is_clean_startup_disconnect(&DisplayErr(
+            "failed to bind stdio transport"
+        )));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod cli;
 
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use serde_json::json;
 
@@ -17,15 +17,13 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Fetch(args) => run_fetch(args).await,
-        Command::Cache(args) => {
-            run_cache(args);
-            Ok(())
-        }
+        Command::Cache(args) => run_cache(args),
     }
 }
 
-/// Inspect or clean the on-disk cache.
-fn run_cache(args: CacheArgs) {
+/// Inspect or clean the on-disk cache. Returns an error — and so a non-zero exit
+/// code — when a prune/clear operation fails, so scripts can detect it.
+fn run_cache(args: CacheArgs) -> Result<()> {
     match args.action {
         CacheAction::Info => {
             let r = cache::report();
@@ -45,23 +43,24 @@ fn run_cache(args: CacheArgs) {
                 human_bytes(r.total_bytes())
             );
         }
-        CacheAction::Prune { older_than } => match cache::prune(older_than) {
-            Ok(p) => println!(
+        CacheAction::Prune { older_than } => {
+            let p = cache::prune(older_than).context("pruning cache")?;
+            println!(
                 "pruned {} entries older than {older_than}s ({} freed)",
                 p.removed,
                 human_bytes(p.bytes)
-            ),
-            Err(e) => eprintln!("prune failed: {e}"),
-        },
-        CacheAction::Clear => match cache::clear() {
-            Ok(p) => println!(
+            );
+        }
+        CacheAction::Clear => {
+            let p = cache::clear().context("clearing cache")?;
+            println!(
                 "cleared {} entries ({} freed)",
                 p.removed,
                 human_bytes(p.bytes)
-            ),
-            Err(e) => eprintln!("clear failed: {e}"),
-        },
+            );
+        }
     }
+    Ok(())
 }
 
 /// Human-readable byte size (binary units).

--- a/src/render.rs
+++ b/src/render.rs
@@ -137,6 +137,32 @@ fn cap_dom(mut html: String) -> String {
     html
 }
 
+/// Read up to `max` bytes from `reader`, stopping the moment the cap is reached
+/// rather than buffering the entire stream first. This is what makes the render
+/// cap a real memory bound: a hostile page that emits gigabytes of DOM costs us
+/// at most ~`max` bytes before we stop reading and tear the browser down.
+#[cfg(feature = "js")]
+async fn read_capped<R>(reader: &mut R, max: usize) -> std::io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    while buf.len() < max {
+        let n = reader.read(&mut chunk).await?;
+        if n == 0 {
+            break; // EOF
+        }
+        let take = n.min(max - buf.len());
+        buf.extend_from_slice(&chunk[..take]);
+        if take < n {
+            break; // hit the cap mid-chunk
+        }
+    }
+    Ok(buf)
+}
+
 /// Render `url` with a headless browser and return the post-JavaScript DOM.
 ///
 /// `wait` doubles as the virtual-time budget — how long to let JS run.
@@ -151,23 +177,33 @@ pub async fn render_html(url: &str, wait: Duration) -> Result<String> {
     args.push("--dump-dom".into());
     args.push(url.to_string());
 
-    let run = Command::new(&chrome)
+    let mut child = Command::new(&chrome)
         .args(&args)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .output();
-
-    let out = timeout(wait + Duration::from_secs(15), run)
-        .await
-        .context("headless render timed out")?
+        .kill_on_drop(true)
+        .spawn()
         .context("launching headless browser")?;
 
-    if !out.status.success() {
-        bail!("headless browser exited unsuccessfully");
-    }
-    // Cap before decoding so a giant DOM never materialises fully in memory.
-    let capped = &out.stdout[..out.stdout.len().min(MAX_RENDER_BYTES)];
-    let html = String::from_utf8_lossy(capped).into_owned();
+    let mut stdout = child
+        .stdout
+        .take()
+        .context("capturing headless browser stdout")?;
+
+    // Stream the DOM with a hard cap instead of buffering all of stdout: this is
+    // what actually bounds memory. The whole read is bounded by the timeout.
+    let bytes = timeout(
+        wait + Duration::from_secs(15),
+        read_capped(&mut stdout, MAX_RENDER_BYTES),
+    )
+    .await
+    .context("headless render timed out")?
+    .context("reading headless DOM")?;
+
+    // We have what we need; reap the browser (kill_on_drop covers early returns).
+    let _ = child.kill().await;
+
+    let html = String::from_utf8_lossy(&bytes).into_owned();
     if html.trim().is_empty() {
         bail!("headless render produced an empty DOM");
     }
@@ -256,7 +292,11 @@ async fn cdp_session(
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
-    let dom = cdp_eval(&mut ws, id + 1, "document.documentElement.outerHTML").await?;
+    // Slice in the browser so the CDP payload itself is bounded — we never pull
+    // more than the cap over the WebSocket. `cap_dom` is a byte-level backstop on
+    // top (JS `slice` counts UTF-16 units, not bytes).
+    let expr = format!("document.documentElement.outerHTML.slice(0, {MAX_RENDER_BYTES})");
+    let dom = cdp_eval(&mut ws, id + 1, &expr).await?;
     dom.as_str()
         .map(str::to_string)
         .map(cap_dom)
@@ -398,6 +438,24 @@ mod tests {
     fn cap_dom_passes_small_input_through() {
         let small = "<html><body>hi</body></html>".to_string();
         assert_eq!(cap_dom(small.clone()), small);
+    }
+
+    #[cfg(feature = "js")]
+    #[tokio::test]
+    async fn read_capped_stops_at_limit() {
+        let data = vec![b'x'; 100_000];
+        let mut src: &[u8] = &data;
+        let out = read_capped(&mut src, 4096).await.unwrap();
+        assert_eq!(out.len(), 4096); // stopped at the cap, did not read all 100 KB
+    }
+
+    #[cfg(feature = "js")]
+    #[tokio::test]
+    async fn read_capped_returns_all_when_under_limit() {
+        let data = vec![b'y'; 1000];
+        let mut src: &[u8] = &data;
+        let out = read_capped(&mut src, 4096).await.unwrap();
+        assert_eq!(out.len(), 1000); // whole stream fits under the cap
     }
 
     #[cfg(feature = "js")]

--- a/src/render.rs
+++ b/src/render.rs
@@ -163,6 +163,19 @@ where
     Ok(buf)
 }
 
+#[cfg(feature = "js")]
+fn cdp_byte_capped_outer_html_expr(max: usize) -> String {
+    format!(
+        r#"(() => {{
+const html = document.documentElement.outerHTML;
+const encoder = new TextEncoder();
+const bytes = encoder.encode(html);
+const capped = bytes.length > {max} ? bytes.slice(0, {max}) : bytes;
+return new TextDecoder("utf-8", {{ fatal: false }}).decode(capped);
+}})()"#
+    )
+}
+
 /// Render `url` with a headless browser and return the post-JavaScript DOM.
 ///
 /// `wait` doubles as the virtual-time budget — how long to let JS run.
@@ -200,8 +213,17 @@ pub async fn render_html(url: &str, wait: Duration) -> Result<String> {
     .context("headless render timed out")?
     .context("reading headless DOM")?;
 
-    // We have what we need; reap the browser (kill_on_drop covers early returns).
-    let _ = child.kill().await;
+    let hit_cap = bytes.len() == MAX_RENDER_BYTES;
+    if hit_cap {
+        // We intentionally stop reading once the cap is reached; kill Chrome so
+        // it cannot keep writing a huge DOM into the pipe.
+        let _ = child.kill().await;
+    } else {
+        let status = child.wait().await.context("waiting for headless browser")?;
+        if !status.success() {
+            bail!("headless browser exited unsuccessfully");
+        }
+    }
 
     let html = String::from_utf8_lossy(&bytes).into_owned();
     if html.trim().is_empty() {
@@ -292,10 +314,9 @@ async fn cdp_session(
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
-    // Slice in the browser so the CDP payload itself is bounded — we never pull
-    // more than the cap over the WebSocket. `cap_dom` is a byte-level backstop on
-    // top (JS `slice` counts UTF-16 units, not bytes).
-    let expr = format!("document.documentElement.outerHTML.slice(0, {MAX_RENDER_BYTES})");
+    // Cap by UTF-8 bytes in the browser so the CDP payload itself is bounded.
+    // `cap_dom` remains a byte-level backstop after JSON decoding.
+    let expr = cdp_byte_capped_outer_html_expr(MAX_RENDER_BYTES);
     let dom = cdp_eval(&mut ws, id + 1, &expr).await?;
     dom.as_str()
         .map(str::to_string)
@@ -456,6 +477,15 @@ mod tests {
         let mut src: &[u8] = &data;
         let out = read_capped(&mut src, 4096).await.unwrap();
         assert_eq!(out.len(), 1000); // whole stream fits under the cap
+    }
+
+    #[cfg(feature = "js")]
+    #[test]
+    fn cdp_capture_expression_caps_utf8_bytes_in_browser() {
+        let expr = cdp_byte_capped_outer_html_expr(4096);
+        assert!(expr.contains("new TextEncoder()"));
+        assert!(expr.contains("bytes.slice(0, 4096)"));
+        assert!(!expr.contains("outerHTML.slice"));
     }
 
     #[cfg(feature = "js")]


### PR DESCRIPTION
## 摘要

v0.7 收斂三個穩健性缺口 —— 都是「看起來有防護、實際上沒生效或不夠乾淨」的問題。

## 變更內容

### 1. headless DOM cap 改成真正的記憶體上限(`src/render.rs`)
v0.6 加了 `MAX_RENDER_BYTES`(16 MiB),但 `render_html` 用 `Command::output()` —— **整個 stdout 會先被讀進記憶體**,事後再切片,cap 根本沒擋到記憶體爆量。

- 改用 `spawn()` + 新的 `read_capped()` **串流讀取** stdout,讀到 cap 立刻停止並 `kill()` 瀏覽器(`kill_on_drop(true)` 兜底),記憶體上限變成真的 ~16 MiB。
- CDP 路徑改在瀏覽器端 `outerHTML.slice(0, MAX)`,讓 WebSocket payload 本身就受限,`cap_dom` 退為 byte-level backstop。
- 新增 `read_capped` 單元測試(超過上限即止 / 未達上限全讀)。

### 2. `cache` CLI 失敗回傳非零 exit code(`src/main.rs`)
`run_cache` 之前 `eprintln!` 印錯誤後仍讓 `main` 回 `Ok(())` → **prune/clear 失敗也 exit 0**,腳本無從偵測。

- `run_cache` 改回傳 `Result<()>`,prune/clear 用 `?` + `context` 傳出,`main` 自然以非零 exit code 結束。`info` 維持原樣。

### 3. MCP transport robustness(`src/bin/rustbrowser-mcp.rs`)
原本 `serve(stdio()).await?; waiting().await?;` —— 任何 transport 錯誤都裸 `?` 冒泡,連 client 正常斷線都可能被當成錯誤。

- `main` 改回傳 `ExitCode`,明確處理 `serve()` 失敗與 `waiting()` 的 `QuitReason`:
  - `Closed` / `Cancelled` → 乾淨關閉,**exit 0**
  - `JoinError` / transport error → 記 stderr,**exit 1**
  - `#[non_exhaustive]` 未知變體 → 記 log 後當乾淨關閉
- 啟動/關閉/錯誤訊息**只進 stderr**,絕不污染 stdout 協定通道。

## 驗證
- `cargo test`:**43 綠燈**(34 lib + 9 整合)
- `cargo fmt --check`、`cargo clippy --all-targets --all-features -- -D warnings` 全過
- feature build 全過:lean cli、mcp-only、bare lib
- 行為實測:
  - `rustbrowser cache info` → exit 0
  - `rustbrowser-mcp` 啟動印 stderr,stdin EOF 時乾淨失敗(無 hang/panic、無 stdout 污染)