### PR TITLE
v1.0.0 穩定版:schema 凍結、安全文件、semver 承諾、三平台 CI/release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           check_size target/release/rustbrowser-mcp $((15 * 1024 * 1024))
 
   build-windows:
-    name: Build (Windows)
+    name: Build & Test (Windows)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -83,3 +83,24 @@ jobs:
 
       - name: Build
         run: cargo build --verbose
+
+      - name: Test
+        run: cargo test --verbose
+
+  build-macos:
+    name: Build & Test (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Test
+        run: cargo test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,14 @@ jobs:
             target: x86_64-pc-windows-msvc
             ext: ".exe"
             archive: zip
+          - os: macos-13
+            target: x86_64-apple-darwin
+            ext: ""
+            archive: tar.gz
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            ext: ""
+            archive: tar.gz
     steps:
       - uses: actions/checkout@v4
 
@@ -57,6 +65,17 @@ jobs:
           else
             tar czf "../rustbrowser-${{ matrix.target }}.tar.gz" *
           fi
+
+      - name: Checksum
+        shell: bash
+        run: |
+          f="rustbrowser-${{ matrix.target }}.${{ matrix.archive }}"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$f" > "$f.sha256"
+          else
+            shasum -a 256 "$f" > "$f.sha256"
+          fi
+          cat "$f.sha256"
 
       - name: Attach to release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to RustBrowser are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/) from `1.0.0` onward (see
+[Stability & versioning](README.md#穩定性與版本-stability--versioning)).
+
+## [1.0.0]
+
+First stable release. The public surface is now **frozen under semver**: CLI
+flags, MCP tool parameters, and the library's public API will not break within
+`1.x`.
+
+### Added
+- **Stability guarantees** — documented semver policy for the CLI, MCP schema,
+  and library API.
+- **`SECURITY.md`** — threat model, the full SSRF/DNS-rebinding/resource-limit
+  defence set, and a vulnerability-reporting process.
+- **`docs/API.md`** — frozen reference for the CLI, the MCP tools, and the
+  `Distilled` JSON output schema, plus a guard test that fails if the CLI flag
+  set or MCP parameter set changes unexpectedly.
+- **CI across Linux, Windows, and macOS**; release binaries for all three
+  (Linux x86_64, Windows x86_64, macOS x86_64 + aarch64) with SHA-256
+  checksums.
+
+## [0.9.0]
+### Added
+- **Extraction profiles** — `article` (Readability, default), `full` (whole
+  `<body>`, no Readability filtering), `metadata` (title + short summary).
+- **Token-output budget** — `--max-output-tokens` truncates Markdown/text at a
+  paragraph boundary; the truncation marker counts toward the hard cap.
+- **Quality diagnostics** — `--diagnostics` reports extraction ratio, link/table
+  counts, headless use, truncation, and a `low_content` warning.
+- **`distill_html`** offline pipeline and a fixed extraction-quality eval set
+  (`tests/fixtures/` + `tests/eval.rs`).
+
+## [0.8.0]
+### Added
+- **Automatic retry** with exponential backoff + jitter for transient failures
+  (connect/timeout, `429`, `5xx`), honouring `Retry-After`.
+- **Per-host concurrency** limit and optional **per-host rate limit**.
+- **robots.txt** support (opt-in `--respect-robots`) via `texting_robots`,
+  enforced per request hop (redirects included) and on cache hits.
+
+## [0.7.0]
+### Fixed
+- Headless DOM cap now **streams** stdout and bounds memory for real.
+- `cache` subcommand returns a non-zero exit code on failure.
+- MCP server handles transport disconnects/errors cleanly with explicit exit
+  codes; diagnostics never pollute stdout.
+
+## [0.6.0]
+### Added
+- End-to-end integration tests (wiremock).
+- `--allow-local` loopback opt-in (private/link-local/metadata stay blocked).
+- `cache info` / `prune` / `clear` maintenance subcommands.
+### Changed
+- Headless sandbox kept enabled by default (`RUSTBROWSER_NO_SANDBOX` to opt out);
+  rendered DOM size cap.
+
+## [0.5.0]
+### Added
+- Whole-page link extraction; headless wait controls (`--js-wait`,
+  CDP `--js-wait-for`); release-binary automation.
+
+## [0.4.0]
+### Added
+- Automatic headless fallback for JS-rendered pages; structured link/table
+  extraction.
+
+## [0.3.0]
+### Added
+- MCP server exposing `fetch_url` / `fetch_urls`.
+
+## [0.2.0]
+### Added
+- On-disk cache (layered fetch + render) and concurrent batch fetching.
+
+## [0.1.0]
+### Added
+- Initial pipeline: fetch → Readability → Markdown → token stats, with a CLI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "rustbrowser"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbrowser"
-version = "0.9.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT"
 description = "Token-lean web content fetcher for LLMs — distills pages to clean Markdown."

--- a/README.md
+++ b/README.md
@@ -224,6 +224,24 @@ cargo build --release --no-default-features --features "cli mcp stats js robots"
 
 CI 會執行 fmt、clippy、build、test、release build,並檢查 release binary 大小:CLI ≤ 10 MiB,MCP ≤ 15 MiB。
 
+## 穩定性與版本 (Stability & versioning)
+
+從 `1.0.0` 起,本專案遵循 [Semantic Versioning](https://semver.org/)。`1.x` 內**保證不破壞**的公開介面:
+
+- **CLI** —— `fetch` 既有旗標與 `cache` 子命令的名稱與語意。
+- **MCP** —— `fetch_url` / `fetch_urls` 工具與其參數名稱、型別。
+- **函式庫** —— `rustbrowser` crate 的公開 API(`distill`、`distill_many`、`distill_html`、`DistillOptions`、`Distilled` 等)。
+- **JSON 輸出** —— `--format json` / MCP `format=json` 之 `Distilled` 結構既有欄位。
+
+**不在 semver 保證內**(可在 minor/patch 改動):
+
+- 精確的 Markdown 文字輸出 —— 擷取與轉換的啟發法會持續改進,內容會變。
+- token 估算的絕對數值(tokenizer 是近似)。
+- 診斷欄位的新增、`low_content` 等門檻的調整。
+- 內部模組、未公開項目、磁碟快取格式。
+
+新增旗標/參數/欄位屬於相容變更(minor)。移除或改名既有者屬於破壞變更,只會在下一個 major。棄用會先在文件標記、保留至少一個 minor 週期。完整逐版變更見 [CHANGELOG.md](CHANGELOG.md);安全防護與威脅模型見 [SECURITY.md](SECURITY.md);凍結介面的完整參考見 [docs/API.md](docs/API.md)。
+
 ## 演進路徑
 
 - ✅ **v0.1(MVP)** — 核心管線 + CLI:抓取 → 萃取 → Markdown → token 統計
@@ -235,6 +253,7 @@ CI 會執行 fmt、clippy、build、test、release build,並檢查 release binar
 - ✅ **v0.7(穩健性)** — headless DOM cap 改串流讀取真正限制記憶體 · `cache` 失敗回傳非零 exit code · MCP transport 明確處理斷線/錯誤(乾淨關閉、診斷只進 stderr)
 - ✅ **v0.8(禮貌抓取)** — 暫時性失敗自動重試(指數退避 + `Retry-After`)· per-host 並發上限 · per-host 速率限制 · robots.txt(opt-in)
 - ✅ **v0.9(擷取品質)** — 擷取 profile(article/full/metadata)· token 預算截斷 · 品質診斷 · `distill_html` 離線管線 + 固定評測集
+- ✅ **v1.0(穩定版)** — CLI/MCP schema 凍結(+ 守門測試)· 完整安全文件(`SECURITY.md`)· semver 承諾 + `CHANGELOG.md` · CI 覆蓋 Linux/Windows/macOS · 三平台 release binaries + checksums
 
 ## 技術棧
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,118 @@
+# Security Policy
+
+RustBrowser fetches web content from URLs that are often **chosen by an LLM or
+an untrusted upstream** — exactly the setting where Server-Side Request Forgery
+(SSRF) and resource-exhaustion attacks matter. Security is therefore a primary
+design goal, not an afterthought. This document describes the threat model, the
+defences in place, and how to report a vulnerability.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| `1.x`   | ✅ security fixes |
+| `< 1.0` | ❌ please upgrade |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+- Preferred: open a **private GitHub Security Advisory** on the repository
+  (`Security` → `Report a vulnerability`).
+- Include: affected version/commit, a description, and a minimal reproduction
+  (a URL, an HTML fixture, or a sequence of options).
+
+We aim to acknowledge a report within a few days, agree on a disclosure
+timeline, and credit reporters who wish to be named.
+
+## Threat model
+
+The adversary controls, or can influence, **the target URL and the bytes the
+server returns** (including redirects, DNS answers, and response size). The
+attacker's goals we defend against:
+
+1. **SSRF** — coerce RustBrowser into reaching internal/non-public network
+   space: loopback, private LANs, cloud metadata (`169.254.169.254`),
+   link-local, CGNAT, or IPv6-embedded equivalents.
+2. **DNS rebinding** — pass the safety check with a public IP, then have the
+   *connection* land on internal space via a second, attacker-controlled DNS
+   answer (low TTL).
+3. **Redirect / cache laundering** — slip an internal target in through an HTTP
+   redirect, or through a URL previously written to the on-disk cache.
+4. **Resource exhaustion** — exhaust memory/CPU with enormous responses, a
+   gigantic post-JavaScript DOM, or a flood of requests.
+
+Out of scope: the security of the host's Chrome/Edge install, the user's own
+network policy, and content correctness (RustBrowser distils, it does not
+vouch for what a page claims).
+
+## Defences
+
+### URL & network boundary (SSRF)
+
+- **Scheme allowlist** — only `http` and `https` are fetched; everything else
+  (`file:`, `ftp:`, `gopher:`, …) is refused before any I/O.
+- **IP block-list** — connections to non-public addresses are refused:
+  loopback, RFC 1918 private ranges, link-local **including the
+  `169.254.169.254` cloud-metadata address**, unspecified, broadcast,
+  multicast, **CGNAT `100.64.0.0/10`**, and **`0.0.0.0/8`**. For IPv6:
+  loopback, unspecified, multicast, unique-local (`fc00::/7`) and unicast
+  link-local (`fe80::/10`). **IPv4-mapped** (`::ffff:a.b.c.d`) and **NAT64
+  well-known** (`64:ff9b::/96`) addresses are decoded back to their embedded
+  IPv4 and re-checked, so they cannot smuggle an internal address past the
+  filter.
+- **DNS-rebinding protection at the connection layer** — a custom
+  `reqwest::dns::Resolve` resolver screens **every resolved address against the
+  same block-list** and hands reqwest only the addresses that pass. reqwest
+  dials exactly those addresses, so there is no second, unscreened DNS lookup a
+  rebinding/low-TTL record could divert. (TLS SNI and certificate validation
+  still use the original hostname.)
+- **Per-hop redirect re-validation** — every redirect `Location`, after being
+  resolved, is re-checked against all of the above before it is followed.
+- **Cache re-validation** — a URL read back from the on-disk cache is
+  re-validated before it is served, so a stale entry cannot bypass current
+  policy.
+
+### `allow_local` opt-in
+
+`--allow-local` / `allow_local` exists for hitting local dev servers and for
+the integration test suite. It frees **loopback only** (`127.0.0.0/8`, `::1`,
+`localhost`). Private LANs, link-local, CGNAT, and the cloud-metadata address
+**remain blocked even when it is set** — including across redirects, which the
+test suite explicitly verifies.
+
+### robots.txt fetches
+
+When `--respect-robots` is enabled, the `robots.txt` request reuses the same
+SSRF-safe client, so a `robots.txt` that redirects toward internal space is
+screened by the connection-layer resolver just like any other request.
+
+### Resource limits
+
+- **Response body cap** — the decoded body is bounded (`--max-bytes`, default
+  8 MiB), read incrementally so an unbounded response cannot be buffered.
+- **Headless DOM cap** — post-JavaScript DOM capture is streamed and stopped at
+  16 MiB; the browser is then killed. The CDP path also slices the DOM in the
+  browser so the captured payload itself is bounded.
+- **Token-output budget** — `--max-output-tokens` hard-caps the distilled
+  output size.
+- **Politeness limits** — per-host concurrency and an optional per-host rate
+  limit bound the load RustBrowser places on any single host.
+- **No retry of blocked requests** — an SSRF-blocked connection is never
+  retried (it would never succeed); only genuine transient failures back off.
+
+### Headless rendering
+
+Headless Chrome/Edge renders untrusted pages, so the **sandbox is kept enabled
+by default**. `--no-sandbox` is *not* passed unless the operator explicitly
+sets `RUSTBROWSER_NO_SANDBOX=1` (for containers or root where the sandbox
+cannot initialise). Headless rendering is also off the hot path: the lean HTTP
+fetch is the default and the browser is only launched when needed.
+
+## Hardening checklist for operators
+
+- Run with the default profile of limits; only raise `--max-bytes` /
+  `--max-output-tokens` when you understand the memory cost.
+- Leave `RUSTBROWSER_NO_SANDBOX` **unset** unless you must run headless as root.
+- Do not pass `--allow-local` to pipelines that fetch attacker-influenced URLs.
+- Keep the host browser updated; RustBrowser relies on it for JS rendering.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,109 @@
+# API Reference (frozen for 1.x)
+
+This is the stable public surface of RustBrowser. Under
+[semver](../README.md#穩定性與版本-stability--versioning), nothing here is removed
+or renamed within `1.x`; new flags/params/fields may be **added**. A guard test
+(`tests/schema_freeze.rs` and the MCP schema test) fails if the CLI flag set or
+MCP parameter set drifts from this document.
+
+## CLI
+
+### `rustbrowser fetch <url>...`
+
+Positional: one or more URLs (multiple are fetched concurrently as a batch).
+
+| Flag | Type / values | Default | Meaning |
+|---|---|---|---|
+| `--format` | `markdown` \| `text` \| `json` | `markdown` | Output format. |
+| `--selector` | CSS selector | — | Extract matching elements instead of running a profile. |
+| `--profile` | `article` \| `full` \| `metadata` | `article` | Content selection (ignored when `--selector` is set). |
+| `--stats` | flag | off | Print token-savings stats to stderr. |
+| `--diagnostics` | flag | off | Print extraction-quality diagnostics to stderr (always present in JSON). |
+| `--max-output-tokens` | integer | — | Truncate Markdown/text output to this many tokens. |
+| `--timeout` | seconds | `20` | Request timeout. |
+| `--max-bytes` | bytes | `8388608` | Cap on decoded response body. |
+| `--no-cache` | flag | off | Skip the on-disk cache. |
+| `--cache-ttl` | seconds | `3600` | Cache freshness window. |
+| `--concurrency` | integer | `8` | Max concurrent requests for a multi-URL batch. |
+| `--links` | flag | off | Extract main-content links as structured data. |
+| `--links-all` | flag | off | Extract ALL links (whole page) for crawling. |
+| `--tables` | flag | off | Extract tables as structured data. |
+| `--js` | `off` \| `auto` \| `always` | `auto` | Headless JS-rendering fallback. |
+| `--js-wait` | milliseconds | — | Headless wait / virtual-time budget. |
+| `--js-wait-for` | CSS selector | — | Wait until this selector appears (CDP). |
+| `--allow-local` | flag | off | Permit loopback targets (only loopback; see SECURITY.md). |
+| `--max-retries` | integer | `2` | Retry transient failures (connect/timeout, 429, 5xx). |
+| `--per-host-concurrency` | integer | `4` | Max simultaneous requests per host (0 = unlimited). |
+| `--rate-limit` | requests/sec | `0` | Per-host rate limit (0 = off). |
+| `--respect-robots` | flag | off | Honour each host's robots.txt. |
+
+### `rustbrowser cache <action>`
+
+| Action | Meaning |
+|---|---|
+| `info` | Show cache entry counts and total size. |
+| `prune --older-than <secs>` | Remove entries older than the given age (default `3600`). |
+| `clear` | Remove all cached entries. |
+
+Exit code is non-zero if a `prune`/`clear` operation fails.
+
+## MCP tools
+
+The `rustbrowser-mcp` stdio server exposes two tools.
+
+### `fetch_url`
+
+| Param | Type | Default |
+|---|---|---|
+| `url` | string (required) | — |
+| `format` | string (`markdown`/`text`/`json`) | `markdown` |
+| `selector` | string | — |
+| `profile` | string (`article`/`full`/`metadata`) | `article` |
+| `stats` | bool | `false` |
+| `diagnostics` | bool | `false` |
+| `max_output_tokens` | integer | — |
+| `timeout_secs` | integer | `20` |
+| `max_bytes` | integer | `8388608` |
+| `no_cache` | bool | `false` |
+| `cache_ttl` | integer | `3600` |
+| `extract_links` | bool | `false` |
+| `extract_tables` | bool | `false` |
+| `links_full` | bool | `false` |
+| `js` | string (`off`/`auto`/`always`) | `auto` |
+| `js_wait` | integer (ms) | — |
+| `js_wait_for` | string | — |
+| `allow_local` | bool | `false` |
+| `max_retries` | integer | `2` |
+| `per_host_concurrency` | integer | `4` |
+| `rate_limit` | number (req/sec) | `0` |
+| `respect_robots` | bool | `false` |
+
+### `fetch_urls`
+
+Same parameters as `fetch_url` **except** `url`/`selector`, plus:
+
+| Param | Type | Default |
+|---|---|---|
+| `urls` | array of string (required) | — |
+| `concurrency` | integer | `8` |
+
+## JSON output schema (`Distilled`)
+
+`--format json` (and MCP `format=json`) serialise this object. Optional fields
+are omitted when absent.
+
+| Field | Type | Notes |
+|---|---|---|
+| `final_url` | string | URL after redirects. |
+| `status` | integer | HTTP status. |
+| `title` | string | Extracted title. |
+| `byline` | string? | Author, if found. |
+| `excerpt` | string? | Summary, if found. |
+| `markdown` | string | Distilled Markdown (token-budgeted if requested). |
+| `stats` | object? | `{raw_bytes, raw_tokens, output_tokens, saved_tokens, saved_ratio}` — present with `stats`. |
+| `links` | array? | `{href, text}` — present with link extraction. |
+| `tables` | array? | `{headers, rows}` — present with table extraction. |
+| `diagnostics` | object? | `{profile, raw_bytes, output_chars, output_tokens, extraction_ratio, link_count, table_count, used_headless, truncated, low_content}` — present with `diagnostics`. |
+
+> The exact Markdown text and token numbers are **not** semver-stable — see the
+> stability policy. The field names and shapes above are.

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,7 +18,7 @@ Positional: one or more URLs (multiple are fetched concurrently as a batch).
 | `--selector` | CSS selector | — | Extract matching elements instead of running a profile. |
 | `--profile` | `article` \| `full` \| `metadata` | `article` | Content selection (ignored when `--selector` is set). |
 | `--stats` | flag | off | Print token-savings stats to stderr. |
-| `--diagnostics` | flag | off | Print extraction-quality diagnostics to stderr (always present in JSON). |
+| `--diagnostics` | flag | off | Print extraction-quality diagnostics to stderr; with `--format json`, include diagnostics in the JSON result. |
 | `--max-output-tokens` | integer | — | Truncate Markdown/text output to this many tokens. |
 | `--timeout` | seconds | `20` | Request timeout. |
 | `--max-bytes` | bytes | `8388608` | Cap on decoded response body. |

--- a/src/bin/rustbrowser-mcp.rs
+++ b/src/bin/rustbrowser-mcp.rs
@@ -499,4 +499,85 @@ mod tests {
             "failed to bind stdio transport"
         )));
     }
+
+    /// Property names present in a generated JSON schema's `properties` object.
+    fn schema_props(schema: schemars::Schema) -> std::collections::BTreeSet<String> {
+        serde_json::to_value(schema)
+            .expect("schema serialises")
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .map(|o| o.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    // The MCP parameter sets are frozen for 1.x (see docs/API.md). Adding a param
+    // is fine — extend the list. Removing/renaming one should fail here first.
+
+    #[test]
+    fn fetch_url_params_are_frozen() {
+        let props = schema_props(schemars::schema_for!(FetchParams));
+        for key in [
+            "url",
+            "format",
+            "selector",
+            "profile",
+            "stats",
+            "diagnostics",
+            "max_output_tokens",
+            "timeout_secs",
+            "max_bytes",
+            "no_cache",
+            "cache_ttl",
+            "extract_links",
+            "extract_tables",
+            "links_full",
+            "js",
+            "js_wait",
+            "js_wait_for",
+            "allow_local",
+            "max_retries",
+            "per_host_concurrency",
+            "rate_limit",
+            "respect_robots",
+        ] {
+            assert!(
+                props.contains(key),
+                "frozen FetchParams field {key} missing"
+            );
+        }
+    }
+
+    #[test]
+    fn fetch_urls_params_are_frozen() {
+        let props = schema_props(schemars::schema_for!(FetchManyParams));
+        for key in [
+            "urls",
+            "concurrency",
+            "format",
+            "profile",
+            "stats",
+            "diagnostics",
+            "max_output_tokens",
+            "timeout_secs",
+            "max_bytes",
+            "no_cache",
+            "cache_ttl",
+            "extract_links",
+            "extract_tables",
+            "links_full",
+            "js",
+            "js_wait",
+            "js_wait_for",
+            "allow_local",
+            "max_retries",
+            "per_host_concurrency",
+            "rate_limit",
+            "respect_robots",
+        ] {
+            assert!(
+                props.contains(key),
+                "frozen FetchManyParams field {key} missing"
+            );
+        }
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,7 +138,7 @@ pub struct FetchArgs {
     #[arg(long)]
     pub max_output_tokens: Option<usize>,
 
-    /// Print extraction-quality diagnostics to stderr (included in JSON output).
+    /// Print extraction-quality diagnostics to stderr (or in JSON output).
     #[arg(long)]
     pub diagnostics: bool,
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -19,9 +19,13 @@ use tokio::time::sleep;
 use url::{Host, Url};
 
 /// Default User-Agent. A real browser-ish UA reduces the chance of being
-/// served a degraded/blocked page, while still being honest about origin.
-const DEFAULT_UA: &str =
-    "Mozilla/5.0 (compatible; RustBrowser/0.1; +https://github.com/rustbrowser)";
+/// served a degraded/blocked page, while still being honest about origin. The
+/// version tracks the crate version automatically.
+const DEFAULT_UA: &str = concat!(
+    "Mozilla/5.0 (compatible; RustBrowser/",
+    env!("CARGO_PKG_VERSION"),
+    "; +https://github.com/JoshuaWangTW/RustBrowser)"
+);
 
 /// Tunables for a fetch.
 #[derive(Debug, Clone)]

--- a/tests/schema_freeze.rs
+++ b/tests/schema_freeze.rs
@@ -1,0 +1,72 @@
+//! Schema-freeze guard for the CLI surface.
+//!
+//! The flag set below is frozen for `1.x` (see `docs/API.md`). Adding a flag is
+//! fine — extend the list. Removing or renaming one is a breaking change and
+//! should turn this test red first. Runs the built binary's `--help`, so it
+//! checks the real parser, not a copy of it.
+
+/// Every long flag `fetch` must keep exposing in `1.x`.
+const FETCH_FLAGS: &[&str] = &[
+    "--format",
+    "--selector",
+    "--profile",
+    "--stats",
+    "--diagnostics",
+    "--max-output-tokens",
+    "--timeout",
+    "--max-bytes",
+    "--no-cache",
+    "--cache-ttl",
+    "--concurrency",
+    "--links",
+    "--links-all",
+    "--tables",
+    "--js",
+    "--js-wait",
+    "--js-wait-for",
+    "--allow-local",
+    "--max-retries",
+    "--per-host-concurrency",
+    "--rate-limit",
+    "--respect-robots",
+];
+
+/// Run the built `rustbrowser` binary and capture combined stdout+stderr.
+/// Returns `None` if the binary was not built (e.g. `--no-default-features`),
+/// in which case the freeze check is skipped rather than failing to compile.
+fn help(args: &[&str]) -> Option<String> {
+    let bin = option_env!("CARGO_BIN_EXE_rustbrowser")?;
+    let out = std::process::Command::new(bin)
+        .args(args)
+        .output()
+        .expect("running the rustbrowser binary");
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    Some(s)
+}
+
+#[test]
+fn fetch_flag_set_is_frozen() {
+    let Some(h) = help(&["fetch", "--help"]) else {
+        return; // binary not built without the `cli` feature
+    };
+    for flag in FETCH_FLAGS {
+        assert!(
+            h.contains(flag),
+            "frozen flag {flag} is missing from `fetch --help`"
+        );
+    }
+}
+
+#[test]
+fn cache_subcommands_are_frozen() {
+    let Some(h) = help(&["cache", "--help"]) else {
+        return;
+    };
+    for sub in ["info", "prune", "clear"] {
+        assert!(
+            h.contains(sub),
+            "frozen `cache` subcommand {sub} is missing"
+        );
+    }
+}

--- a/tests/schema_freeze.rs
+++ b/tests/schema_freeze.rs
@@ -70,3 +70,14 @@ fn cache_subcommands_are_frozen() {
         );
     }
 }
+
+#[test]
+fn cache_prune_flags_are_frozen() {
+    let Some(h) = help(&["cache", "prune", "--help"]) else {
+        return;
+    };
+    assert!(
+        h.contains("--older-than"),
+        "frozen `cache prune` flag --older-than is missing"
+    );
+}


### PR DESCRIPTION
## 摘要

把 RustBrowser 推到 **1.0 穩定版**:公開介面凍結並以 semver 承諾、安全與穩定性文件齊備、CI/release 覆蓋三平台。功能面延續 v0.9(此 PR 從已合併的 v0.9 master 出發),本版專注**穩定化**,不改變既有行為。

## 變更內容

### 1. CLI/MCP schema 凍結 + 守門測試
- **`docs/API.md`** —— 完整列出 `fetch` 旗標、`cache` 子命令、`fetch_url`/`fetch_urls` 參數、`Distilled` JSON schema,標記 1.x 凍結。
- **`tests/schema_freeze.rs`** —— 跑**真實** `fetch --help` / `cache --help`,斷言凍結旗標集合存在(用 `option_env!` 在無 cli feature 時自動跳過)。
- **MCP schema 測試**(mcp binary 內)—— 用 `schemars::schema_for!` 斷言 `FetchParams`/`FetchManyParams` 的參數集合。旗標/參數被移除或改名即紅燈。

### 2. 完整安全文件:`SECURITY.md`
威脅模型(SSRF / DNS rebinding / redirect-cache 洗白 / 資源耗盡)、各層防護(scheme allowlist、IP block-list 含 metadata/CGNAT/NAT64、連線層 resolver、per-hop redirect 重驗、cache 重驗)、`allow_local` 語意、headless sandbox 政策、資源上限、**漏洞回報流程**、supported versions、operator hardening checklist。

### 3. semver 承諾 + `CHANGELOG.md`
- README 新增**穩定性政策**:`1.x` 不破壞 CLI 旗標、MCP 參數、lib 公開 API、JSON 欄位;**不保證**精確 Markdown 輸出與 token 絕對數值(啟發法會改進)。
- `CHANGELOG.md` 以 Keep a Changelog 格式彙整 v0.1 → v1.0。

### 4. CI/release 三平台 + checksums
- **`ci.yml`** —— Windows 與 macOS job 也跑 `cargo test`(原本 Windows 只 build);新增 macOS job。Linux 仍是完整 lint/test/feature/size。
- **`release.yml`** —— 新增 macOS `x86_64`(macos-13)+ `aarch64`(macos-latest)target;所有產物附 **SHA-256 checksums**。

### 5. 1.0 小修
- User-Agent 改用 `env!("CARGO_PKG_VERSION")` 自動跟版號 + 改為真實 repo URL。

## 驗證
- `cargo test`:**79 綠燈**(53 lib + 4 mcp〔2 startup + 2 schema〕+ 6 eval + 14 整合 + 2 schema-freeze)
- `cargo fmt --check`、`cargo clippy --all-targets --all-features -- -D warnings`
- feature build 全過(含不含 robots 的 lean cli / bare lib)
- release binary:CLI **8.40 MiB**、MCP **8.99 MiB**(預算內)
- **本 PR 的 CI 會首次在 Linux + Windows + macOS 三平台跑** —— macOS 是新覆蓋面

## 注意
- v0.9 的功能在本版一併發佈為 **v1.0.0**(未單獨 tag v0.9.0)。
- `release.yml` 的 macOS target / checksums 只在 tag 推送時實際執行;本 PR 先讓三平台 **CI** 把關。