### PR TITLE
v1.2.0 Session + Static Actions:有狀態瀏覽 + 表單提交

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,19 @@ observe.
 
 ### Added
 - **Sessions** (`Session` in the library; `session_start` / `session_observe` /
-  `session_follow` / `session_submit_form` MCP tools) — keep a cookie jar,
-  current URL, redirect history, and the last snapshot's action tree.
+  `session_follow` / `session_submit_form` / `session_close` MCP tools) — keep
+  a cookie jar, current URL, redirect history, and the last snapshot's action
+  tree.
 - **HTML form submission** — GET forms become a query string; POST forms send a
   urlencoded body. The form's own defaults (hidden CSRF fields, selected
   options) are merged with the caller's values automatically. POST is single-
   attempt (never silently retried).
 - **Dangerous-action confirmation** — a non-GET submit is described but **not
   sent** unless the caller passes `confirm=true`.
+- **Session lifecycle guardrails** — `session_close` forgets cookies/snapshots,
+  and the MCP server caps live sessions.
+- **POST redirect hardening** — 307/308 POST redirects only preserve submitted
+  body on same-origin hops; cross-origin body forwarding is blocked.
 - Every session request reuses the same SSRF-screened path as a plain fetch.
 
 ## [1.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to RustBrowser are documented here. The format is based on
 [Semantic Versioning](https://semver.org/) from `1.0.0` onward (see
 [Stability & versioning](README.md#穩定性與版本-stability--versioning)).
 
+## [1.2.0]
+
+Second Browser-Use step: **stateful sessions** so an agent can act, not just
+observe.
+
+### Added
+- **Sessions** (`Session` in the library; `session_start` / `session_observe` /
+  `session_follow` / `session_submit_form` MCP tools) — keep a cookie jar,
+  current URL, redirect history, and the last snapshot's action tree.
+- **HTML form submission** — GET forms become a query string; POST forms send a
+  urlencoded body. The form's own defaults (hidden CSRF fields, selected
+  options) are merged with the caller's values automatically. POST is single-
+  attempt (never silently retried).
+- **Dangerous-action confirmation** — a non-GET submit is described but **not
+  sent** unless the caller passes `confirm=true`.
+- Every session request reuses the same SSRF-screened path as a plain fetch.
+
 ## [1.1.0]
 
 First step toward **RB-first Browser Use**: RB can now tell an agent what is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +542,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +622,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1266,6 +1313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1436,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1531,6 +1590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1617,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -1736,6 +1817,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "h2",
@@ -1821,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "rustbrowser"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2343,6 +2426,37 @@ dependencies = [
  "lazy_static",
  "regex",
  "rustc-hash",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbrowser"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 license = "MIT"
 description = "Token-lean web content fetcher for LLMs — distills pages to clean Markdown."
@@ -14,7 +14,7 @@ dom_smoothie = "0.17.0"
 encoding_rs = "0.8"
 futures = "0.3.32"
 htmd = "0.5.4"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots", "gzip", "brotli", "deflate", "charset", "http2"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots", "gzip", "brotli", "deflate", "charset", "http2", "cookies"] }
 rmcp = { version = "1.7.0", features = ["server", "transport-io", "macros"], optional = true }
 schemars = { version = "1.2.1", optional = true }
 scraper = "0.27.0"

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ CI 會執行 fmt、clippy、build、test、release build,並檢查 release binar
 - ✅ **v0.9(擷取品質)** — 擷取 profile(article/full/metadata)· token 預算截斷 · 品質診斷 · `distill_html` 離線管線 + 固定評測集
 - ✅ **v1.0(穩定版)** — CLI/MCP schema 凍結(+ 守門測試)· 完整安全文件(`SECURITY.md`)· semver 承諾 + `CHANGELOG.md` · CI 覆蓋 Linux/Windows/macOS · 三平台 release binaries + checksums
 - ✅ **v1.1(Actionable Observe)** — action tree(links/forms/buttons/downloads + 穩定 action_id)· MCP `observe_url` 工具 · action token 上限 · action 抽取評測。Browser Use 的第一步:RB 先能告訴 agent「這頁有哪些可操作的東西」
+- ✅ **v1.2(Session + Static Actions)** — 有狀態 session(cookie jar / current URL / redirect history / last snapshot)· MCP `session_start`/`session_observe`/`session_follow`/`session_submit_form` · HTML 表單提交(GET 帶 query、POST 帶 body,自動帶 hidden/selected 預設值)· 高風險(非 GET)action 需 `confirm=true` 才送。Browser Use 第二步:能 act,不只 observe
 
 ## 技術棧
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ CI 會執行 fmt、clippy、build、test、release build,並檢查 release binar
 - ✅ **v0.9(擷取品質)** — 擷取 profile(article/full/metadata)· token 預算截斷 · 品質診斷 · `distill_html` 離線管線 + 固定評測集
 - ✅ **v1.0(穩定版)** — CLI/MCP schema 凍結(+ 守門測試)· 完整安全文件(`SECURITY.md`)· semver 承諾 + `CHANGELOG.md` · CI 覆蓋 Linux/Windows/macOS · 三平台 release binaries + checksums
 - ✅ **v1.1(Actionable Observe)** — action tree(links/forms/buttons/downloads + 穩定 action_id)· MCP `observe_url` 工具 · action token 上限 · action 抽取評測。Browser Use 的第一步:RB 先能告訴 agent「這頁有哪些可操作的東西」
-- ✅ **v1.2(Session + Static Actions)** — 有狀態 session(cookie jar / current URL / redirect history / last snapshot)· MCP `session_start`/`session_observe`/`session_follow`/`session_submit_form` · HTML 表單提交(GET 帶 query、POST 帶 body,自動帶 hidden/selected 預設值)· 高風險(非 GET)action 需 `confirm=true` 才送。Browser Use 第二步:能 act,不只 observe
+- ✅ **v1.2(Session + Static Actions)** — 有狀態 session(cookie jar / current URL / redirect history / last snapshot)· MCP `session_start`/`session_observe`/`session_follow`/`session_submit_form`/`session_close` · HTML 表單提交(GET 帶 query、POST 帶 body,自動帶 hidden/selected 預設值)· 高風險(非 GET)action 需 `confirm=true` 才送 · 跨 origin 307/308 POST body 轉送會被阻擋。Browser Use 第二步:能 act,不只 observe
 
 ## 技術棧
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -109,6 +109,23 @@ sets `RUSTBROWSER_NO_SANDBOX=1` (for containers or root where the sandbox
 cannot initialise). Headless rendering is also off the hot path: the lean HTTP
 fetch is the default and the browser is only launched when needed.
 
+### Sessions & form submission
+
+Stateful sessions (`session_*`) keep a per-session cookie jar and submit HTML
+forms. The relevant safeguards:
+
+- **Same SSRF boundary** — `follow`/`submit` resolve URLs from the page's action
+  tree (already restricted to `http`/`https`) and send them through the exact
+  same screened path as a plain fetch; redirects are re-validated per hop.
+- **Confirmation for dangerous actions** — a non-GET submit (POST/PUT/DELETE/…)
+  is **never sent automatically**. It is described back to the caller and only
+  executed when `confirm=true` is passed. RB never POSTs on an agent's behalf
+  without an explicit go-ahead.
+- **POST is single-attempt** — a POST is never silently retried, so a
+  non-idempotent action cannot be double-submitted by the retry logic.
+- **Cookies are in-memory and per-session** — they live only for the life of the
+  session object and are not written to disk.
+
 ## Hardening checklist for operators
 
 - Run with the default profile of limits; only raise `--max-bytes` /

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -123,8 +123,12 @@ forms. The relevant safeguards:
   without an explicit go-ahead.
 - **POST is single-attempt** — a POST is never silently retried, so a
   non-idempotent action cannot be double-submitted by the retry logic.
+- **POST body redirects stay same-origin** — 307/308 redirects preserve method
+  and body under HTTP semantics, so RB blocks cross-origin 307/308 POST
+  redirects instead of forwarding submitted fields to a new origin.
 - **Cookies are in-memory and per-session** — they live only for the life of the
-  session object and are not written to disk.
+  session object and are not written to disk. `session_close` explicitly
+  forgets a session, and the MCP server caps the number of live sessions.
 
 ## Hardening checklist for operators
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -51,7 +51,8 @@ Exit code is non-zero if a `prune`/`clear` operation fails.
 
 ## MCP tools
 
-The `rustbrowser-mcp` stdio server exposes three tools.
+The `rustbrowser-mcp` stdio server exposes stateless fetch tools and stateful
+session tools.
 
 ### `fetch_url`
 
@@ -101,8 +102,10 @@ Same parameters as `fetch_url` **except** `url`/`selector`, plus:
 ### Session tools (stateful Browser Use)
 
 A session keeps a cookie jar, the current URL, a redirect history, and the last
-snapshot (with its action tree). All return the session view as JSON
-(`{session_id, current_url, redirect_history, snapshot}`).
+snapshot (with its action tree). Navigation and successful submit tools return
+the session view as JSON
+(`{session_id, current_url, redirect_history, snapshot}`). `session_close`
+forgets the session and returns `{session_id, closed}`.
 
 | Tool | Params | Notes |
 |---|---|---|
@@ -110,6 +113,7 @@ snapshot (with its action tree). All return the session view as JSON
 | `session_observe` | `session_id`, `url` | Navigate the session to `url` (keeps cookies). |
 | `session_follow` | `session_id`, `action_id` | Follow a `link_*`/`download_*` from the last snapshot. |
 | `session_submit_form` | `session_id`, `form_id`, `values` (object), `confirm` (bool) | Submit a `form_*`, merging `values` over the form's defaults. GET submits immediately; a non-GET is **withheld unless `confirm=true`** (returns `{needs_confirmation, would_submit}`). |
+| `session_close` | `session_id` | Close a session and forget its cookies, URL, history, and snapshot. |
 
 ## JSON output schema (`Distilled`)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,6 +98,19 @@ Same parameters as `fetch_url` **except** `url`/`selector`, plus:
 | `urls` | array of string (required) | — |
 | `concurrency` | integer | `8` |
 
+### Session tools (stateful Browser Use)
+
+A session keeps a cookie jar, the current URL, a redirect history, and the last
+snapshot (with its action tree). All return the session view as JSON
+(`{session_id, current_url, redirect_history, snapshot}`).
+
+| Tool | Params | Notes |
+|---|---|---|
+| `session_start` | `url` (required); `profile`, `max_actions`, `timeout_secs`, `allow_local`, `respect_robots` | Opens `url`, returns a `session_id` + first snapshot. |
+| `session_observe` | `session_id`, `url` | Navigate the session to `url` (keeps cookies). |
+| `session_follow` | `session_id`, `action_id` | Follow a `link_*`/`download_*` from the last snapshot. |
+| `session_submit_form` | `session_id`, `form_id`, `values` (object), `confirm` (bool) | Submit a `form_*`, merging `values` over the form's defaults. GET submits immediately; a non-GET is **withheld unless `confirm=true`** (returns `{needs_confirmation, would_submit}`). |
+
 ## JSON output schema (`Distilled`)
 
 `--format json` (and MCP `format=json`) serialise this object. Optional fields

--- a/src/bin/rustbrowser-mcp.rs
+++ b/src/bin/rustbrowser-mcp.rs
@@ -30,6 +30,8 @@ use rustbrowser::{DistillOptions, Distilled, JsMode, Profile, distill, distill_m
 /// One live browsing session, guarded so a single session's actions serialise.
 type SharedSession = Arc<AsyncMutex<Session>>;
 
+const MAX_LIVE_SESSIONS: usize = 64;
+
 #[derive(Clone)]
 struct RustBrowserServer {
     // Read by the `#[tool_handler]` macro's generated ServerHandler impl,
@@ -62,6 +64,53 @@ impl RustBrowserServer {
             .get(id)
             .cloned()
             .ok_or_else(|| rmcp::ErrorData::invalid_params(format!("unknown session '{id}'"), None))
+    }
+
+    fn ensure_session_capacity(&self) -> Result<(), rmcp::ErrorData> {
+        let len = self
+            .sessions
+            .lock()
+            .expect("session map mutex poisoned")
+            .len();
+        if len >= MAX_LIVE_SESSIONS {
+            return Err(rmcp::ErrorData::invalid_params(
+                format!(
+                    "too many live sessions; close one with session_close first (limit {MAX_LIVE_SESSIONS})"
+                ),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    fn insert_session(&self, id: String, session: Session) -> Result<(), rmcp::ErrorData> {
+        let mut sessions = self.sessions.lock().expect("session map mutex poisoned");
+        if sessions.len() >= MAX_LIVE_SESSIONS {
+            return Err(rmcp::ErrorData::invalid_params(
+                format!(
+                    "too many live sessions; close one with session_close first (limit {MAX_LIVE_SESSIONS})"
+                ),
+                None,
+            ));
+        }
+        sessions.insert(id, Arc::new(AsyncMutex::new(session)));
+        Ok(())
+    }
+
+    fn close_session(&self, id: &str) -> Result<(), rmcp::ErrorData> {
+        let removed = self
+            .sessions
+            .lock()
+            .expect("session map mutex poisoned")
+            .remove(id);
+        if removed.is_some() {
+            Ok(())
+        } else {
+            Err(rmcp::ErrorData::invalid_params(
+                format!("unknown session '{id}'"),
+                None,
+            ))
+        }
     }
 }
 
@@ -270,6 +319,12 @@ struct SessionFollowParams {
     session_id: String,
     /// A `link_*` or `download_*` action id from the last snapshot.
     action_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SessionCloseParams {
+    /// The session id to close and forget.
+    session_id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -611,6 +666,7 @@ impl RustBrowserServer {
         &self,
         Parameters(p): Parameters<SessionStartParams>,
     ) -> Result<String, rmcp::ErrorData> {
+        self.ensure_session_capacity()?;
         let mut session = Session::new(session_opts(&p))
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
         session.observe(&p.url).await.map_err(|e| {
@@ -618,10 +674,7 @@ impl RustBrowserServer {
         })?;
         let id = Self::next_session_id();
         let view = session_view(&id, &session)?;
-        self.sessions
-            .lock()
-            .expect("session map mutex poisoned")
-            .insert(id, Arc::new(AsyncMutex::new(session)));
+        self.insert_session(id, session)?;
         Ok(view)
     }
 
@@ -655,6 +708,22 @@ impl RustBrowserServer {
             .await
             .map_err(|e| rmcp::ErrorData::invalid_params(format!("follow failed: {e}"), None))?;
         session_view(&p.session_id, &session)
+    }
+
+    #[tool(
+        description = "Close a SESSION and forget its cookies, current URL, history, and snapshot."
+    )]
+    async fn session_close(
+        &self,
+        Parameters(p): Parameters<SessionCloseParams>,
+    ) -> Result<String, rmcp::ErrorData> {
+        self.close_session(&p.session_id)?;
+        let view = json!({
+            "session_id": p.session_id,
+            "closed": true,
+        });
+        serde_json::to_string_pretty(&view)
+            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))
     }
 
     #[tool(
@@ -700,8 +769,9 @@ impl ServerHandler for RustBrowserServer {
              plus an action tree (links/forms/buttons/downloads with stable action_ids). For \
              multi-step flows use a SESSION: session_start opens a page and keeps cookies + \
              history, then session_observe / session_follow / session_submit_form drive it by \
-             action_id (GET forms submit immediately; non-GET needs confirm=true). All return \
-             clean output instead of raw HTML, saving 75-98% of tokens.",
+             action_id (GET forms submit immediately; non-GET needs confirm=true). Use \
+             session_close to forget cookies and release the session. All return clean output \
+             instead of raw HTML, saving 75-98% of tokens.",
         )
     }
 }
@@ -901,6 +971,11 @@ mod tests {
                 "frozen SessionFollowParams field {key} missing"
             );
         }
+        let close = schema_props(schemars::schema_for!(SessionCloseParams));
+        assert!(
+            close.contains("session_id"),
+            "frozen SessionCloseParams field session_id missing"
+        );
         let submit = schema_props(schemars::schema_for!(SessionSubmitFormParams));
         for key in ["session_id", "form_id", "values", "confirm"] {
             assert!(

--- a/src/bin/rustbrowser-mcp.rs
+++ b/src/bin/rustbrowser-mcp.rs
@@ -5,7 +5,10 @@
 //! Transport is stdio: the MCP protocol speaks over stdout, so NOTHING may be
 //! printed to stdout except protocol frames. All diagnostics go to stderr.
 
+use std::collections::HashMap;
 use std::process::ExitCode;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use rmcp::{
@@ -19,23 +22,60 @@ use rmcp::{
 };
 use serde::Deserialize;
 use serde_json::json;
+use tokio::sync::Mutex as AsyncMutex;
 
+use rustbrowser::session::{Session, SubmitOutcome};
 use rustbrowser::{DistillOptions, Distilled, JsMode, Profile, distill, distill_many};
 
-#[derive(Debug, Clone)]
+/// One live browsing session, guarded so a single session's actions serialise.
+type SharedSession = Arc<AsyncMutex<Session>>;
+
+#[derive(Clone)]
 struct RustBrowserServer {
     // Read by the `#[tool_handler]` macro's generated ServerHandler impl,
     // which the dead-code lint can't see through.
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
+    /// Live browsing sessions, keyed by id. The map lock is held only briefly to
+    /// look up / insert; per-session work locks the inner `AsyncMutex`.
+    sessions: Arc<Mutex<HashMap<String, SharedSession>>>,
 }
+
+static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 impl RustBrowserServer {
     fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
+
+    fn next_session_id() -> String {
+        format!("sess_{}", SESSION_COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn lookup_session(&self, id: &str) -> Result<SharedSession, rmcp::ErrorData> {
+        self.sessions
+            .lock()
+            .expect("session map mutex poisoned")
+            .get(id)
+            .cloned()
+            .ok_or_else(|| rmcp::ErrorData::invalid_params(format!("unknown session '{id}'"), None))
+    }
+}
+
+/// Serialise a session's public state (id, current URL, history, snapshot) as
+/// JSON for return to the agent.
+fn session_view(id: &str, session: &Session) -> Result<String, rmcp::ErrorData> {
+    let view = json!({
+        "session_id": id,
+        "current_url": session.current_url(),
+        "redirect_history": session.redirect_history(),
+        "snapshot": session.snapshot(),
+    });
+    serde_json::to_string_pretty(&view)
+        .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -193,6 +233,75 @@ struct FetchManyParams {
     /// entries (avoids action-tree blowup).
     #[serde(default)]
     max_actions: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SessionStartParams {
+    /// The URL to open as the session's first page.
+    url: String,
+    /// Content profile: "article" (default), "full" (whole body), or "metadata".
+    #[serde(default)]
+    profile: Option<String>,
+    /// Cap each action category, form fields, and select options at this many.
+    #[serde(default)]
+    max_actions: Option<usize>,
+    /// Request timeout in seconds (default 20).
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+    /// Permit loopback/localhost targets (only loopback freed).
+    #[serde(default)]
+    allow_local: Option<bool>,
+    /// Respect each host's robots.txt (default false).
+    #[serde(default)]
+    respect_robots: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SessionObserveParams {
+    /// The session id from session_start.
+    session_id: String,
+    /// The URL to navigate to in this session.
+    url: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SessionFollowParams {
+    /// The session id from session_start.
+    session_id: String,
+    /// A `link_*` or `download_*` action id from the last snapshot.
+    action_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SessionSubmitFormParams {
+    /// The session id from session_start.
+    session_id: String,
+    /// A `form_*` action id from the last snapshot.
+    form_id: String,
+    /// Field name → value to submit (merged over the form's own defaults such as
+    /// hidden CSRF fields and selected options).
+    #[serde(default)]
+    values: HashMap<String, String>,
+    /// Required to actually send a non-GET (dangerous) submit. Without it, a
+    /// POST/etc. is described but NOT sent.
+    #[serde(default)]
+    confirm: Option<bool>,
+}
+
+/// Build the per-session distill options. Sessions always observe the action
+/// tree and run live (no cache).
+fn session_opts(p: &SessionStartParams) -> DistillOptions {
+    DistillOptions {
+        timeout: Duration::from_secs(p.timeout_secs.unwrap_or(20)),
+        profile: parse_profile(p.profile.as_deref()),
+        max_actions: p.max_actions,
+        allow_local: p.allow_local.unwrap_or(false),
+        respect_robots: p.respect_robots.unwrap_or(false),
+        extract_actions: true,
+        diagnostics: true,
+        use_cache: false,
+        ..Default::default()
+    }
 }
 
 fn parse_js_mode(js: Option<&str>) -> JsMode {
@@ -494,6 +603,92 @@ impl RustBrowserServer {
         }
         Ok(out)
     }
+
+    #[tool(
+        description = "START a stateful browsing SESSION (Browser Use). Opens a URL and keeps a cookie jar, the current URL, a redirect history, and the page snapshot with its action tree. Returns a session_id plus that snapshot. Drive the session afterwards with session_observe / session_follow / session_submit_form using the action_ids in the snapshot. Cookies persist, so login and search flows work without a real browser."
+    )]
+    async fn session_start(
+        &self,
+        Parameters(p): Parameters<SessionStartParams>,
+    ) -> Result<String, rmcp::ErrorData> {
+        let mut session = Session::new(session_opts(&p))
+            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+        session.observe(&p.url).await.map_err(|e| {
+            rmcp::ErrorData::internal_error(format!("session start failed: {e}"), None)
+        })?;
+        let id = Self::next_session_id();
+        let view = session_view(&id, &session)?;
+        self.sessions
+            .lock()
+            .expect("session map mutex poisoned")
+            .insert(id, Arc::new(AsyncMutex::new(session)));
+        Ok(view)
+    }
+
+    #[tool(
+        description = "Navigate an existing SESSION to a new URL (keeps its cookies). Returns the updated snapshot + action tree."
+    )]
+    async fn session_observe(
+        &self,
+        Parameters(p): Parameters<SessionObserveParams>,
+    ) -> Result<String, rmcp::ErrorData> {
+        let shared = self.lookup_session(&p.session_id)?;
+        let mut session = shared.lock().await;
+        session
+            .observe(&p.url)
+            .await
+            .map_err(|e| rmcp::ErrorData::internal_error(format!("observe failed: {e}"), None))?;
+        session_view(&p.session_id, &session)
+    }
+
+    #[tool(
+        description = "FOLLOW a link (or download) in a SESSION by its action_id (e.g. link_3) from the last snapshot. Returns the updated snapshot + action tree."
+    )]
+    async fn session_follow(
+        &self,
+        Parameters(p): Parameters<SessionFollowParams>,
+    ) -> Result<String, rmcp::ErrorData> {
+        let shared = self.lookup_session(&p.session_id)?;
+        let mut session = shared.lock().await;
+        session
+            .follow(&p.action_id)
+            .await
+            .map_err(|e| rmcp::ErrorData::invalid_params(format!("follow failed: {e}"), None))?;
+        session_view(&p.session_id, &session)
+    }
+
+    #[tool(
+        description = "SUBMIT a form in a SESSION by its form_id (e.g. form_0), merging your field values over the form's own defaults (hidden CSRF fields, selected options). GET forms (search/filter) submit immediately. A non-GET (POST/etc.) form is DANGEROUS: it is only described, not sent, unless you pass confirm=true — RB never silently submits on your behalf."
+    )]
+    async fn session_submit_form(
+        &self,
+        Parameters(p): Parameters<SessionSubmitFormParams>,
+    ) -> Result<String, rmcp::ErrorData> {
+        let shared = self.lookup_session(&p.session_id)?;
+        let mut session = shared.lock().await;
+        let values: Vec<(String, String)> = p.values.into_iter().collect();
+        let outcome = session
+            .submit_form(&p.form_id, &values, p.confirm.unwrap_or(false))
+            .await
+            .map_err(|e| rmcp::ErrorData::internal_error(format!("submit failed: {e}"), None))?;
+        match outcome {
+            SubmitOutcome::Submitted => session_view(&p.session_id, &session),
+            SubmitOutcome::NeedsConfirmation {
+                method,
+                action,
+                fields,
+            } => {
+                let view = json!({
+                    "session_id": p.session_id,
+                    "needs_confirmation": true,
+                    "message": "Dangerous (non-GET) submit withheld. Re-call session_submit_form with confirm=true to send it.",
+                    "would_submit": { "method": method, "action": action, "fields": fields },
+                });
+                serde_json::to_string_pretty(&view)
+                    .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))
+            }
+        }
+    }
 }
 
 #[tool_handler]
@@ -502,9 +697,11 @@ impl ServerHandler for RustBrowserServer {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
             "RustBrowser: token-lean web fetching and Browser Use. fetch_url distills one page; \
              fetch_urls fetches many concurrently; observe_url returns a page's distilled content \
-             plus an action tree (links/forms/buttons/downloads with stable action_ids) for \
-             deciding what to do next. All return clean output instead of raw HTML, saving 75-98% \
-             of tokens, with an on-disk cache and automatic headless rendering for JS-heavy pages.",
+             plus an action tree (links/forms/buttons/downloads with stable action_ids). For \
+             multi-step flows use a SESSION: session_start opens a page and keeps cookies + \
+             history, then session_observe / session_follow / session_submit_form drive it by \
+             action_id (GET forms submit immediately; non-GET needs confirm=true). All return \
+             clean output instead of raw HTML, saving 75-98% of tokens.",
         )
     }
 }
@@ -670,6 +867,45 @@ mod tests {
             assert!(
                 props.contains(key),
                 "frozen FetchManyParams field {key} missing"
+            );
+        }
+    }
+
+    #[test]
+    fn session_tool_params_are_frozen() {
+        let start = schema_props(schemars::schema_for!(SessionStartParams));
+        for key in [
+            "url",
+            "profile",
+            "max_actions",
+            "timeout_secs",
+            "allow_local",
+            "respect_robots",
+        ] {
+            assert!(
+                start.contains(key),
+                "frozen SessionStartParams field {key} missing"
+            );
+        }
+        let observe = schema_props(schemars::schema_for!(SessionObserveParams));
+        for key in ["session_id", "url"] {
+            assert!(
+                observe.contains(key),
+                "frozen SessionObserveParams field {key} missing"
+            );
+        }
+        let follow = schema_props(schemars::schema_for!(SessionFollowParams));
+        for key in ["session_id", "action_id"] {
+            assert!(
+                follow.contains(key),
+                "frozen SessionFollowParams field {key} missing"
+            );
+        }
+        let submit = schema_props(schemars::schema_for!(SessionSubmitFormParams));
+        for key in ["session_id", "form_id", "values", "confirm"] {
+            assert!(
+                submit.contains(key),
+                "frozen SessionSubmitFormParams field {key} missing"
             );
         }
     }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -271,6 +271,17 @@ impl Fetcher {
                     bail!("too many redirects while requesting {url}");
                 }
                 if let Some(next) = redirect_target(&current, &resp, allow_local)? {
+                    if method == reqwest::Method::POST
+                        && form_body.is_some()
+                        && matches!(status.as_u16(), 307 | 308)
+                        && !same_origin(&current, &next)
+                    {
+                        bail!(
+                            "cross-origin POST redirect blocked: {} -> {}",
+                            origin_label(&current),
+                            origin_label(&next)
+                        );
+                    }
                     current = next;
                     // 307/308 preserve method + body; all others become GET.
                     if !matches!(status.as_u16(), 307 | 308) {
@@ -646,6 +657,20 @@ fn redirect_target(
         .with_context(|| format!("invalid redirect Location: {location}"))?;
     parse_and_validate_url_basics(next.as_str(), allow_local)?;
     Ok(Some(next))
+}
+
+fn same_origin(a: &Url, b: &Url) -> bool {
+    a.scheme() == b.scheme()
+        && a.host_str() == b.host_str()
+        && a.port_or_known_default() == b.port_or_known_default()
+}
+
+fn origin_label(url: &Url) -> String {
+    let host = url.host_str().unwrap_or("<unknown>");
+    match url.port_or_known_default() {
+        Some(port) => format!("{}://{}:{}", url.scheme(), host, port),
+        None => format!("{}://{}", url.scheme(), host),
+    }
 }
 
 async fn read_limited_body(resp: &mut reqwest::Response, max_bytes: usize) -> Result<Vec<u8>> {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -52,6 +52,9 @@ pub struct FetchOptions {
     /// Consult each host's robots.txt and refuse paths it disallows for our
     /// User-Agent (off by default; requires the `robots` feature to enforce).
     pub respect_robots: bool,
+    /// Keep an in-memory cookie jar on the client so `Set-Cookie` persists across
+    /// requests. Off for stateless fetches; on for sessions.
+    pub cookie_store: bool,
 }
 
 impl Default for FetchOptions {
@@ -66,8 +69,18 @@ impl Default for FetchOptions {
             per_host_concurrency: 4,
             min_request_interval: Duration::ZERO,
             respect_robots: false,
+            cookie_store: false,
         }
     }
+}
+
+/// How a form is submitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitMethod {
+    /// Form data becomes the URL query string (idempotent).
+    Get,
+    /// Form data becomes a urlencoded request body (non-idempotent).
+    Post,
 }
 
 /// Outcome of a successful fetch.
@@ -111,6 +124,8 @@ impl Fetcher {
             .brotli(true)
             .deflate(true)
             .redirect(reqwest::redirect::Policy::none())
+            // Persist cookies across a session's requests when asked.
+            .cookie_store(opts.cookie_store)
             // Resolve + screen IPs at the connection layer so reqwest dials the
             // exact addresses we validated — no separate pre-flight lookup that a
             // rebinding/low-TTL DNS could diverge from. Set once on the shared
@@ -144,6 +159,30 @@ impl Fetcher {
         self.fetch_with_retries(url, start).await
     }
 
+    /// Submit a form. `Get` appends the fields as the query string and reuses the
+    /// full retried GET path; `Post` sends a urlencoded body in a **single
+    /// attempt** — POST is non-idempotent and must never be silently re-sent.
+    /// Both go through the same SSRF screening and redirect re-validation.
+    pub async fn submit(
+        &self,
+        action_url: &str,
+        method: SubmitMethod,
+        fields: &[(String, String)],
+    ) -> Result<FetchResult> {
+        match method {
+            SubmitMethod::Get => {
+                let url = build_query_url(action_url, fields)?;
+                self.fetch(&url).await
+            }
+            SubmitMethod::Post => {
+                let start = parse_and_validate_url_basics(action_url, self.opts.allow_local)?;
+                self.fetch_once(action_url, start, Some(fields))
+                    .await
+                    .map(|a| a.res)
+            }
+        }
+    }
+
     /// Enforce robots.txt for a URL string under this fetcher's policy. This is
     /// also used before serving cache hits so `respect_robots` cannot be bypassed
     /// by content fetched under a looser previous policy.
@@ -168,7 +207,7 @@ impl Fetcher {
         let max = self.opts.max_retries;
         let mut attempt = 0usize;
         loop {
-            match self.fetch_once(url, start.clone()).await {
+            match self.fetch_once(url, start.clone(), None).await {
                 Ok(a) if attempt < max && is_retryable_status(a.res.status) => {
                     let delay = a.retry_after.unwrap_or_else(|| backoff_delay(attempt));
                     attempt += 1;
@@ -186,9 +225,22 @@ impl Fetcher {
 
     /// A single fetch attempt: follows redirects (each safety-checked) and reads
     /// the final body. Status is surfaced as-is (no error on 4xx/5xx).
-    async fn fetch_once(&self, url: &str, start: Url) -> Result<Attempt> {
+    async fn fetch_once(
+        &self,
+        url: &str,
+        start: Url,
+        body: Option<&[(String, String)]>,
+    ) -> Result<Attempt> {
         let allow_local = self.opts.allow_local;
         let mut current = start;
+        // A form submit sends POST + body on the first hop; redirects downgrade
+        // to GET (dropping the body) except 307/308, which preserve the method.
+        let mut method = if body.is_some() {
+            reqwest::Method::POST
+        } else {
+            reqwest::Method::GET
+        };
+        let mut form_body: Option<Vec<(String, String)>> = body.map(<[_]>::to_vec);
 
         for redirect_count in 0..=self.opts.max_redirects {
             // First line: cheap, DNS-free checks (scheme, literal IPs, localhost).
@@ -202,9 +254,13 @@ impl Fetcher {
             let host = host_key(&current);
             let _permit = self.gate.enter(&host).await;
 
-            let mut resp = self
-                .client
-                .get(current.clone())
+            let mut builder = self.client.request(method.clone(), current.clone());
+            if method == reqwest::Method::POST
+                && let Some(fields) = &form_body
+            {
+                builder = builder.form(fields);
+            }
+            let mut resp = builder
                 .send()
                 .await
                 .with_context(|| format!("requesting {current}"))?;
@@ -216,6 +272,11 @@ impl Fetcher {
                 }
                 if let Some(next) = redirect_target(&current, &resp, allow_local)? {
                     current = next;
+                    // 307/308 preserve method + body; all others become GET.
+                    if !matches!(status.as_u16(), 307 | 308) {
+                        method = reqwest::Method::GET;
+                        form_body = None;
+                    }
                     continue;
                 }
             }
@@ -253,6 +314,21 @@ impl Fetcher {
 /// Convenience fetch for callers that do not need client reuse.
 pub async fn fetch(url: &str, opts: &FetchOptions) -> Result<FetchResult> {
     Fetcher::new(opts.clone())?.fetch(url).await
+}
+
+/// Build `action_url` with `fields` as its query string. HTML GET-form semantics:
+/// the submitted data replaces any query already on the action URL.
+fn build_query_url(action_url: &str, fields: &[(String, String)]) -> Result<String> {
+    let mut url =
+        Url::parse(action_url).with_context(|| format!("invalid form action: {action_url}"))?;
+    url.set_query(None);
+    {
+        let mut pairs = url.query_pairs_mut();
+        for (k, v) in fields {
+            pairs.append_pair(k, v);
+        }
+    }
+    Ok(url.to_string())
 }
 
 /// The gate key for a URL: its host (domain or IP literal). Politeness limits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod fetch;
 pub mod render;
 #[cfg(feature = "robots")]
 pub mod robots;
+pub mod session;
 pub mod structured;
 pub mod tokens;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,266 @@
+//! Stateful browsing session for Browser Use (Observe → Act → Verify).
+//!
+//! A `Session` keeps a cookie jar, the current URL, a redirect history, and the
+//! last observed snapshot (distilled content + action tree). An agent drives it
+//! by `observe`-ing a URL, then `follow`-ing a link or `submit_form`-ing by the
+//! stable `action_id`s in the last snapshot — never opening a real browser.
+//!
+//! Safety: every request reuses the same SSRF-screened path as plain fetches.
+//! A non-GET form submit is a *dangerous* action and is refused unless the
+//! caller explicitly confirms — RB never silently POSTs on an agent's behalf.
+
+use anyhow::{Result, anyhow, bail};
+
+use crate::actions::FormAction;
+use crate::fetch::{FetchOptions, FetchResult, Fetcher, SubmitMethod};
+use crate::{DistillOptions, Distilled, distill_html};
+
+/// A stateful browsing session.
+pub struct Session {
+    fetcher: Fetcher,
+    /// Distill options used for every snapshot (always extracts the action tree).
+    opts: DistillOptions,
+    current_url: Option<String>,
+    redirect_history: Vec<String>,
+    last_snapshot: Option<Distilled>,
+}
+
+/// What happened when a form submit was requested.
+#[derive(Debug, Clone)]
+pub enum SubmitOutcome {
+    /// The form was submitted and the snapshot updated.
+    Submitted,
+    /// A dangerous (non-GET) submit was withheld pending confirmation. Nothing
+    /// was sent; this describes exactly what *would* be sent.
+    NeedsConfirmation {
+        method: String,
+        action: String,
+        fields: Vec<(String, String)>,
+    },
+}
+
+impl Session {
+    /// Start a session. The given options seed every snapshot; cookies persist
+    /// across requests and the action tree is always extracted.
+    pub fn new(opts: DistillOptions) -> Result<Self> {
+        let mut fopts = FetchOptions {
+            timeout: opts.timeout,
+            max_bytes: opts.max_bytes,
+            allow_local: opts.allow_local,
+            max_retries: opts.max_retries,
+            per_host_concurrency: opts.per_host_concurrency,
+            min_request_interval: opts.min_request_interval,
+            respect_robots: opts.respect_robots,
+            cookie_store: true,
+            ..Default::default()
+        };
+        if let Some(ua) = &opts.user_agent {
+            fopts.user_agent = ua.clone();
+        }
+
+        // Snapshots always carry the action tree; caching is off so a session
+        // always sees live state.
+        let mut snapshot_opts = opts;
+        snapshot_opts.extract_actions = true;
+        snapshot_opts.use_cache = false;
+
+        Ok(Self {
+            fetcher: Fetcher::new(fopts)?,
+            opts: snapshot_opts,
+            current_url: None,
+            redirect_history: Vec::new(),
+            last_snapshot: None,
+        })
+    }
+
+    pub fn current_url(&self) -> Option<&str> {
+        self.current_url.as_deref()
+    }
+
+    pub fn redirect_history(&self) -> &[String] {
+        &self.redirect_history
+    }
+
+    pub fn snapshot(&self) -> Option<&Distilled> {
+        self.last_snapshot.as_ref()
+    }
+
+    /// Fetch `url` and make it the current snapshot.
+    pub async fn observe(&mut self, url: &str) -> Result<&Distilled> {
+        let result = self.fetcher.fetch(url).await?;
+        self.record(result);
+        self.snapshot_ref()
+    }
+
+    /// Follow a `link_*` / `download_*` action from the last snapshot.
+    pub async fn follow(&mut self, action_id: &str) -> Result<&Distilled> {
+        let href = self.resolve_followable(action_id)?;
+        let result = self.fetcher.fetch(&href).await?;
+        self.record(result);
+        self.snapshot_ref()
+    }
+
+    /// Submit a `form_*` from the last snapshot, merging the form's own default
+    /// values (hidden fields, selected options) with the caller's `values`.
+    /// A non-GET submit requires `confirm = true`.
+    pub async fn submit_form(
+        &mut self,
+        form_id: &str,
+        values: &[(String, String)],
+        confirm: bool,
+    ) -> Result<SubmitOutcome> {
+        let form = self.resolve_form(form_id)?;
+        let method = if form.method.eq_ignore_ascii_case("POST") {
+            SubmitMethod::Post
+        } else {
+            SubmitMethod::Get
+        };
+        let fields = merge_form_values(&form, values);
+
+        // Non-GET is a dangerous action: never auto-execute without confirmation.
+        if method != SubmitMethod::Get && !confirm {
+            return Ok(SubmitOutcome::NeedsConfirmation {
+                method: form.method.clone(),
+                action: form.action.clone(),
+                fields,
+            });
+        }
+
+        let result = self.fetcher.submit(&form.action, method, &fields).await?;
+        self.record(result);
+        Ok(SubmitOutcome::Submitted)
+    }
+
+    fn record(&mut self, result: FetchResult) {
+        self.current_url = Some(result.final_url.clone());
+        self.redirect_history.push(result.final_url.clone());
+        if let Ok(mut snap) = distill_html(&result.html, &result.final_url, &self.opts) {
+            // distill_html stamps a synthetic 200; carry the real HTTP status.
+            snap.status = result.status;
+            self.last_snapshot = Some(snap);
+        }
+    }
+
+    fn snapshot_ref(&self) -> Result<&Distilled> {
+        self.last_snapshot
+            .as_ref()
+            .ok_or_else(|| anyhow!("snapshot could not be distilled"))
+    }
+
+    /// Resolve a `link_*` or `download_*` action id to its absolute URL.
+    fn resolve_followable(&self, action_id: &str) -> Result<String> {
+        let actions = self
+            .last_snapshot
+            .as_ref()
+            .and_then(|s| s.actions.as_ref())
+            .ok_or_else(|| anyhow!("no action tree to follow; observe a page first"))?;
+        if let Some(l) = actions.links.iter().find(|l| l.action_id == action_id) {
+            return Ok(l.href.clone());
+        }
+        if let Some(d) = actions.downloads.iter().find(|d| d.action_id == action_id) {
+            return Ok(d.href.clone());
+        }
+        bail!("no followable action '{action_id}' in the current snapshot")
+    }
+
+    fn resolve_form(&self, form_id: &str) -> Result<FormAction> {
+        self.last_snapshot
+            .as_ref()
+            .and_then(|s| s.actions.as_ref())
+            .and_then(|a| a.forms.iter().find(|f| f.action_id == form_id))
+            .cloned()
+            .ok_or_else(|| anyhow!("no form '{form_id}' in the current snapshot"))
+    }
+}
+
+/// Merge a form's own default field values with caller-supplied `values`
+/// (caller wins). Hidden fields (e.g. CSRF tokens) and selected options are
+/// carried automatically so the submit is well-formed.
+fn merge_form_values(form: &FormAction, values: &[(String, String)]) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    for f in &form.fields {
+        if f.name.is_empty() {
+            continue;
+        }
+        if let Some(v) = &f.value {
+            out.push((f.name.clone(), v.clone()));
+        } else if f.kind == "select"
+            && let Some(opt) = f.options.iter().find(|o| o.selected).or(f.options.first())
+        {
+            out.push((f.name.clone(), opt.value.clone()));
+        }
+    }
+    for (k, v) in values {
+        out.retain(|(ek, _)| ek != k);
+        out.push((k.clone(), v.clone()));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::{FormField, FormOption};
+
+    fn form() -> FormAction {
+        FormAction {
+            action_id: "form_0".into(),
+            method: "POST".into(),
+            action: "https://example.com/login".into(),
+            submit_id: "form_0.submit".into(),
+            fields: vec![
+                FormField {
+                    name: "csrf".into(),
+                    kind: "hidden".into(),
+                    value: Some("tok".into()),
+                    options: vec![],
+                    required: false,
+                },
+                FormField {
+                    name: "user".into(),
+                    kind: "text".into(),
+                    value: None,
+                    options: vec![],
+                    required: true,
+                },
+                FormField {
+                    name: "role".into(),
+                    kind: "select".into(),
+                    value: None,
+                    options: vec![
+                        FormOption {
+                            value: "admin".into(),
+                            label: "Admin".into(),
+                            selected: false,
+                        },
+                        FormOption {
+                            value: "user".into(),
+                            label: "User".into(),
+                            selected: true,
+                        },
+                    ],
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn merge_keeps_defaults_and_applies_user_values() {
+        let merged = merge_form_values(&form(), &[("user".into(), "alice".into())]);
+        // Hidden csrf carried automatically.
+        assert!(merged.contains(&("csrf".into(), "tok".into())));
+        // User value applied.
+        assert!(merged.contains(&("user".into(), "alice".into())));
+        // Selected option's value used for the select.
+        assert!(merged.contains(&("role".into(), "user".into())));
+    }
+
+    #[test]
+    fn user_value_overrides_default() {
+        let merged = merge_form_values(&form(), &[("csrf".into(), "evil".into())]);
+        let csrf: Vec<_> = merged.iter().filter(|(k, _)| k == "csrf").collect();
+        assert_eq!(csrf.len(), 1);
+        assert_eq!(csrf[0].1, "evil");
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,7 +9,7 @@
 //! A non-GET form submit is a *dangerous* action and is refused unless the
 //! caller explicitly confirms — RB never silently POSTs on an agent's behalf.
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 
 use crate::actions::FormAction;
 use crate::fetch::{FetchOptions, FetchResult, Fetcher, SubmitMethod};
@@ -88,7 +88,7 @@ impl Session {
     /// Fetch `url` and make it the current snapshot.
     pub async fn observe(&mut self, url: &str) -> Result<&Distilled> {
         let result = self.fetcher.fetch(url).await?;
-        self.record(result);
+        self.record(result)?;
         self.snapshot_ref()
     }
 
@@ -96,7 +96,7 @@ impl Session {
     pub async fn follow(&mut self, action_id: &str) -> Result<&Distilled> {
         let href = self.resolve_followable(action_id)?;
         let result = self.fetcher.fetch(&href).await?;
-        self.record(result);
+        self.record(result)?;
         self.snapshot_ref()
     }
 
@@ -127,18 +127,20 @@ impl Session {
         }
 
         let result = self.fetcher.submit(&form.action, method, &fields).await?;
-        self.record(result);
+        self.record(result)?;
         Ok(SubmitOutcome::Submitted)
     }
 
-    fn record(&mut self, result: FetchResult) {
+    fn record(&mut self, result: FetchResult) -> Result<()> {
+        let mut snap = distill_html(&result.html, &result.final_url, &self.opts)
+            .with_context(|| format!("distilling session snapshot for {}", result.final_url))?;
+        // distill_html stamps a synthetic 200; carry the real HTTP status.
+        snap.status = result.status;
+
         self.current_url = Some(result.final_url.clone());
-        self.redirect_history.push(result.final_url.clone());
-        if let Ok(mut snap) = distill_html(&result.html, &result.final_url, &self.opts) {
-            // distill_html stamps a synthetic 200; carry the real HTTP status.
-            snap.status = result.status;
-            self.last_snapshot = Some(snap);
-        }
+        self.redirect_history.push(result.final_url);
+        self.last_snapshot = Some(snap);
+        Ok(())
     }
 
     fn snapshot_ref(&self) -> Result<&Distilled> {

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -1,0 +1,173 @@
+//! End-to-end session flow against a wiremock server: observe → follow link →
+//! submit GET form → submit POST form (with the confirmation gate) → cookie
+//! persistence. Drives the real `Session` over a loopback mock.
+
+use rustbrowser::DistillOptions;
+use rustbrowser::session::{Session, SubmitOutcome};
+use wiremock::matchers::{body_string_contains, header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const HOME: &str = r#"<!DOCTYPE html><html><head><title>Home</title></head><body>
+  <h1>Welcome</h1>
+  <p>This is the home page with enough text for a clean snapshot.</p>
+  <a href="/page2">Go to page two</a>
+  <form method="get" action="/search">
+    <input type="search" name="q">
+    <button type="submit">Search</button>
+  </form>
+  <form method="post" action="/login">
+    <input type="text" name="user">
+    <input type="password" name="pass">
+    <input type="hidden" name="csrf" value="tok42">
+    <button type="submit">Log in</button>
+  </form>
+</body></html>"#;
+
+/// Session options that can reach the loopback mock and use the `full` profile
+/// (no readability minimum-content threshold).
+fn opts() -> DistillOptions {
+    DistillOptions {
+        allow_local: true,
+        profile: rustbrowser::Profile::Full,
+        ..Default::default()
+    }
+}
+
+async fn home(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .insert_header("Set-Cookie", "sid=abc123; Path=/")
+                .set_body_string(HOME),
+        )
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn observe_extracts_actions_and_follows_link() {
+    let server = MockServer::start().await;
+    home(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/page2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string(
+                    "<html><body><h1>Page Two</h1><p>Second page body.</p></body></html>",
+                ),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts()).unwrap();
+    let snap = s.observe(&format!("{}/", server.uri())).await.unwrap();
+    let actions = snap.actions.as_ref().expect("action tree");
+    assert_eq!(actions.links.len(), 1, "one nav link");
+    assert_eq!(actions.forms.len(), 2, "search + login forms");
+
+    // Follow the link by its stable id.
+    s.follow("link_0").await.unwrap();
+    assert!(s.current_url().unwrap().ends_with("/page2"));
+    assert!(s.snapshot().unwrap().markdown.contains("Page Two"));
+}
+
+#[tokio::test]
+async fn get_form_submits_as_query() {
+    let server = MockServer::start().await;
+    home(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .and(query_param("q", "rustlang"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string(
+                    "<html><body><h1>Results</h1><p>Found rustlang.</p></body></html>",
+                ),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts()).unwrap();
+    s.observe(&format!("{}/", server.uri())).await.unwrap();
+    let outcome = s
+        .submit_form("form_0", &[("q".into(), "rustlang".into())], false)
+        .await
+        .unwrap();
+    assert!(matches!(outcome, SubmitOutcome::Submitted));
+    assert!(s.current_url().unwrap().contains("q=rustlang"));
+    assert!(s.snapshot().unwrap().markdown.contains("Results"));
+}
+
+#[tokio::test]
+async fn post_form_needs_confirmation_then_submits() {
+    let server = MockServer::start().await;
+    home(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/login"))
+        .and(body_string_contains("user=alice"))
+        .and(body_string_contains("csrf=tok42")) // hidden field carried automatically
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string(
+                    "<html><body><h1>Logged in</h1><p>Welcome alice.</p></body></html>",
+                ),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts()).unwrap();
+    s.observe(&format!("{}/", server.uri())).await.unwrap();
+
+    // Without confirmation, the POST is described but NOT sent.
+    let values = [
+        ("user".to_string(), "alice".to_string()),
+        ("pass".to_string(), "secret".to_string()),
+    ];
+    let withheld = s.submit_form("form_1", &values, false).await.unwrap();
+    match withheld {
+        SubmitOutcome::NeedsConfirmation { method, fields, .. } => {
+            assert_eq!(method, "POST");
+            assert!(fields.iter().any(|(k, v)| k == "csrf" && v == "tok42"));
+            assert!(fields.iter().any(|(k, v)| k == "user" && v == "alice"));
+        }
+        SubmitOutcome::Submitted => panic!("POST must not auto-submit without confirm"),
+    }
+    // The snapshot must be unchanged (still the home page).
+    assert!(s.snapshot().unwrap().markdown.contains("Welcome"));
+
+    // With confirmation, it goes through.
+    let done = s.submit_form("form_1", &values, true).await.unwrap();
+    assert!(matches!(done, SubmitOutcome::Submitted));
+    assert!(s.snapshot().unwrap().markdown.contains("Logged in"));
+}
+
+#[tokio::test]
+async fn cookies_persist_across_requests() {
+    let server = MockServer::start().await;
+    home(&server).await; // sets Set-Cookie: sid=abc123
+    // /whoami only matches when the session replays the cookie.
+    Mock::given(method("GET"))
+        .and(path("/whoami"))
+        .and(header("cookie", "sid=abc123"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string("<html><body><h1>You are abc123</h1></body></html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts()).unwrap();
+    s.observe(&format!("{}/", server.uri())).await.unwrap(); // receives the cookie
+    let snap = s
+        .observe(&format!("{}/whoami", server.uri()))
+        .await
+        .unwrap();
+    assert_eq!(snap.status, 200, "cookie was not replayed");
+    assert!(snap.markdown.contains("abc123"));
+}

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -147,6 +147,93 @@ async fn post_form_needs_confirmation_then_submits() {
 }
 
 #[tokio::test]
+async fn post_redirect_does_not_forward_body_cross_origin() {
+    let source = MockServer::start().await;
+    let sink = MockServer::start().await;
+    home(&source).await;
+
+    Mock::given(method("POST"))
+        .and(path("/login"))
+        .respond_with(
+            ResponseTemplate::new(307).insert_header("Location", format!("{}/steal", sink.uri())),
+        )
+        .mount(&source)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/steal"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string("<html><body><h1>Leaked</h1></body></html>"),
+        )
+        .mount(&sink)
+        .await;
+
+    let mut s = Session::new(opts()).unwrap();
+    s.observe(&format!("{}/", source.uri())).await.unwrap();
+    let values = [
+        ("user".to_string(), "alice".to_string()),
+        ("pass".to_string(), "secret".to_string()),
+    ];
+
+    let err = s
+        .submit_form("form_1", &values, true)
+        .await
+        .expect_err("cross-origin POST redirect must be blocked");
+
+    assert!(
+        err.to_string()
+            .contains("cross-origin POST redirect blocked")
+    );
+    assert!(
+        s.snapshot().unwrap().markdown.contains("Welcome"),
+        "failed submit should leave the previous snapshot intact"
+    );
+    let received = sink.received_requests().await.expect("recording enabled");
+    assert!(
+        received.is_empty(),
+        "form body was forwarded to redirected origin"
+    );
+}
+
+#[tokio::test]
+async fn failed_distill_does_not_advance_session_state() {
+    let server = MockServer::start().await;
+    home(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/no-heading"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string("<html><body><p>No selected heading here.</p></body></html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(DistillOptions {
+        allow_local: true,
+        selector: Some("h1".to_string()),
+        ..Default::default()
+    })
+    .unwrap();
+    let first_url = format!("{}/", server.uri());
+    s.observe(&first_url).await.unwrap();
+    assert_eq!(s.current_url(), Some(first_url.as_str()));
+    assert_eq!(s.redirect_history().len(), 1);
+    assert!(s.snapshot().unwrap().markdown.contains("Welcome"));
+
+    let err = s
+        .observe(&format!("{}/no-heading", server.uri()))
+        .await
+        .expect_err("selector miss should fail");
+
+    assert!(format!("{err:#}").contains("selector 'h1' matched no elements"));
+    assert_eq!(s.current_url(), Some(first_url.as_str()));
+    assert_eq!(s.redirect_history().len(), 1);
+    assert!(s.snapshot().unwrap().markdown.contains("Welcome"));
+}
+
+#[tokio::test]
 async fn cookies_persist_across_requests() {
     let server = MockServer::start().await;
     home(&server).await; // sets Set-Cookie: sid=abc123


### PR DESCRIPTION
## 摘要

**Browser Use 第二步** —— 從「能 observe」進到「能 act」。新增有狀態 session(cookie jar + 當前 URL + redirect history + 上次快照),agent 可用上次快照裡的 `action_id` 跟 RB 互動:follow 連結、提交 HTML 表單。**不碰 JS click,高風險動作需明確確認。**

## 變更內容

### 1. session-capable Fetcher(`src/fetch.rs`)
- `FetchOptions.cookie_store`(reqwest `cookies` feature)→ 同一 client 的 cookie jar 跨請求保留。
- `Fetcher::submit(action, method, fields)`:**GET** 把欄位變 query string(重用完整 retry GET 路徑);**POST** 送 urlencoded body,**單次嘗試不重試**(非冪等,避免重複送出)。
- 泛化 `fetch_once` 帶 method+body;redirect 方法降級正確(301/302/303→GET,307/308 保留)。**全程沿用同一套 SSRF 防護 + 每 hop 重驗。**

### 2. lib `Session`(`src/session.rs`)
- 狀態:`current_url`、`redirect_history`、`last_snapshot`(含 action tree)。
- `observe(url)` / `follow(action_id)`(由快照解析 link/download href)/ `submit_form(form_id, values, confirm)`(由快照解析 form)。
- `merge_form_values`:自動帶 **hidden(CSRF)+ selected option** 預設值,再以呼叫端 values 覆蓋 → 提交是 well-formed 的。
- 快照透過 `distill_html` 重用整條擷取管線(含 action tree),狀態碼補回真實值。

### 3. 高風險動作確認
非 GET submit **不自動送出** —— 回傳 `NeedsConfirmation { method, action, fields }` 描述「將送什麼」,需 `confirm=true` 才執行。RB 永不替 agent 偷偷 POST。

### 4. MCP session 工具
session registry(per-session `AsyncMutex`)+ `session_start` / `session_observe` / `session_follow` / `session_submit_form`,回 session view(JSON)。schema-freeze 守門 + `docs/API.md` 同步。

## 驗證
- `cargo test`:**98 綠燈**(63 lib + 5 mcp + 9 eval + 14 整合 + 3 schema-freeze + **4 session**)
  - `tests/session.rs`:observe→follow→GET 搜尋→**POST 需確認再送**→**cookie 跨請求保留**,wiremock 端到端
- `cargo fmt --check`、`cargo clippy --all-targets --all-features -- -D warnings`
- feature build 全過(lean cli / mcp-only / bare lib)
- release:CLI **8.45 MiB**、MCP **9.18 MiB**(預算內;cookies 多 ~0.15 MiB)

## semver
相容新增(新 lib 型別 + MCP 工具 + FetchOptions 欄位)→ minor `1.2.0`。既有 fetch/observe 行為不變。

## 守住「優先不要做」
- ❌ 不碰 JS click(只做 HTML form)
- ❌ 不讓 agent 未確認就送高風險 POST
- ✅ 同一 SSRF 邊界、POST 不重試、cookie 只在記憶體

## 後續
V1.3 action loop(planner-friendly state / available_actions / recommended_next / failure_reason、有限自動重試、操作 log)→ V1.4 Chrome fallback broker → V1.5 browser-use benchmark。