### PR TITLE
v1.3.0 — RB Action Loop(planner 視圖 + verify 有限重試 + 操作 log)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,10 @@ jobs:
             target: x86_64-pc-windows-msvc
             ext: ".exe"
             archive: zip
-          - os: macos-13
+          # Both macOS targets build on Apple Silicon (macos-latest); the x86_64
+          # one is cross-compiled. This avoids the deprecated/scarce macos-13
+          # Intel runner, whose queue could stall a release indefinitely.
+          - os: macos-latest
             target: x86_64-apple-darwin
             ext: ""
             archive: tar.gz
@@ -41,6 +44,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       # reqwest -> rustls -> ring needs NASM to assemble on Windows.
       - name: Install NASM
@@ -50,14 +55,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build release
-        run: cargo build --release
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package
         shell: bash
         run: |
           mkdir dist
-          cp "target/release/rustbrowser${{ matrix.ext }}" dist/
-          cp "target/release/rustbrowser-mcp${{ matrix.ext }}" dist/
+          cp "target/${{ matrix.target }}/release/rustbrowser${{ matrix.ext }}" dist/
+          cp "target/${{ matrix.target }}/release/rustbrowser-mcp${{ matrix.ext }}" dist/
           cp README.md LICENSE dist/
           cd dist
           if [ "${{ matrix.archive }}" = "zip" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ and a debug log records what happened.
   follow / GET submit) the snapshot is verified; a retryable failure (429/5xx or
   a transient transport error) is retried up to `max_action_retries` times
   (`session_start` param; default 1, capped at 2), honouring per-host rate
-  limits. A discarded retry never advances session state. `failure_reason`
-  surfaces an HTTP error to the planner.
+  limits. Each loop attempt is one HTTP attempt, so the retry budget is not
+  multiplied by lower-level fetch retries; retries back off exponentially (with
+  jitter) and honour the server's `Retry-After`. A discarded retry never
+  advances session state. `failure_reason` surfaces an HTTP error to the
+  planner.
 - **Operation log** — a per-session `operation_log` (step/op/target/status/
   attempt/outcome/failure_reason) for debugging the loop.
 - New library surface: `rustbrowser::planner` (`LoopView`, `PageState`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to RustBrowser are documented here. The format is based on
 [Semantic Versioning](https://semver.org/) from `1.0.0` onward (see
 [Stability & versioning](README.md#穩定性與版本-stability--versioning)).
 
+## [1.3.0]
+
+Third Browser-Use step: the **Action Loop** — every session reply is now a
+planner-friendly view, idempotent steps are verified and retried within bounds,
+and a debug log records what happened.
+
+### Added
+- **Planner-friendly session view** — session tools now also return a `loop`
+  object: `state` (url/status/title/excerpt + health flags), `available_actions`
+  (links/forms/buttons/downloads flattened to one shape with `action_id`, `kind`,
+  `label`, `target`, form `method`/`fields`, and a `dangerous` flag), and
+  `recommended_next_actions` (cheap heuristics pointing at real `action_id`s —
+  hints only, never auto-executed).
+- **Verify step + bounded auto-retry** — after an idempotent step (observe /
+  follow / GET submit) the snapshot is verified; a retryable failure (429/5xx or
+  a transient transport error) is retried up to `max_action_retries` times
+  (`session_start` param; default 1, capped at 2), honouring per-host rate
+  limits. A discarded retry never advances session state. `failure_reason`
+  surfaces an HTTP error to the planner.
+- **Operation log** — a per-session `operation_log` (step/op/target/status/
+  attempt/outcome/failure_reason) for debugging the loop.
+- New library surface: `rustbrowser::planner` (`LoopView`, `PageState`,
+  `AvailableAction`, `RecommendedAction`, `OpLogEntry`, `verify`),
+  `Session::loop_view` / `log` / `last_failure` / `with_max_action_retries`.
+
+### Safety
+- **Dangerous (non-GET) submits are never auto-executed or auto-retried** — the
+  confirmation gate is unchanged and the retry path applies only to idempotent
+  steps.
+
+### Compatibility
+- The session view is **additive**: the 1.x fields (`session_id`, `current_url`,
+  `redirect_history`, `snapshot`) are unchanged; `loop` and `operation_log` are
+  added alongside them.
+
 ## [1.2.0]
 
 Second Browser-Use step: **stateful sessions** so an agent can act, not just

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "rustbrowser"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbrowser"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "MIT"
 description = "Token-lean web content fetcher for LLMs — distills pages to clean Markdown."

--- a/README.md
+++ b/README.md
@@ -194,6 +194,37 @@ rustbrowser fetch <url> --actions --max-actions 30
 
 > 設計刻意**不做** pixel-level click、不做完整 JS browser、不讓 agent 未經確認就送任意 POST。後續版本(session、表單提交、action loop、Chrome fallback broker)見 [`CHANGELOG.md`](CHANGELOG.md) 與內部路線圖。
 
+## Browser Use:Action Loop(v1.3)
+
+v1.2 讓 session 能 **act**;v1.3 把每次 act 的回傳整理成 **planner-friendly** 格式,讓 LLM 能穩定地跑 Observe → Act → **Verify** 迴圈,而不必每步重讀整包 `Distilled`。每個 session 工具(`session_start`/`session_observe`/`session_follow`/`session_submit_form`)的回傳,在既有欄位之外**新增**:
+
+- **`loop`** —— 規劃用的精簡視圖:
+  - `state` —— 目前頁面(url / status / title / excerpt / content_chars / action_count / low_content / used_headless / steps_taken)。
+  - `available_actions` —— 把 links/forms/buttons/downloads **攤平成統一形狀**,各帶 `action_id`、`kind`、`label`、`target`、(表單的)`method` 與可填 `fields`,以及 `dangerous`(非 GET 標記)。
+  - `recommended_next_actions` —— 便宜誠實的啟發式提示(像是「這看起來是搜尋表單 / 下一頁連結」),指向真實 `action_id`。**只是提示,RB 不會自動執行**。
+  - `failure_reason` —— 該步驟未通過 verify(HTTP 錯誤狀態)時才有;`None` 代表看起來正常。
+- **`operation_log`** —— 每步操作的除錯紀錄(step / op / target / status / attempt / outcome / failure_reason),供 debug 與改版用。
+
+**Verify + 有限自動重試**:idempotent 步驟(observe / follow / GET 表單)抓完會做 verify;遇到**可重試**的暫時性失敗(429/5xx,或暫時性連線錯誤)會再試最多 `max_action_retries` 次(預設 1,上限 2),且維持 per-host rate limit。被丟棄的重試嘗試**不會推進 session 狀態**(`redirect_history` 每次成功導航仍只記一筆)。**高風險(非 GET)提交永遠不會被自動執行,也永遠不會被自動重試。**
+
+```jsonc
+// session_start(url, max_action_retries=2) 之後的回傳(節錄)
+{
+  "session_id": "sess_0",
+  "loop": {
+    "state": { "status": 200, "title": "Search", "action_count": 12, "low_content": false, "steps_taken": 1 },
+    "available_actions": [
+      { "action_id": "form_0", "kind": "form", "method": "GET", "fields": ["q"], "target": "https://e.com/search" },
+      { "action_id": "form_1", "kind": "form", "method": "POST", "dangerous": true, "fields": ["user", "pass"] }
+    ],
+    "recommended_next_actions": [
+      { "action_id": "form_0", "kind": "form", "why": "search/filter form (GET) — submit it to query the site" }
+    ]
+  },
+  "operation_log": [ { "step": 1, "op": "observe", "status": 200, "attempt": 1, "outcome": "ok" } ]
+}
+```
+
 ## 使用方式:給 Claude Code 用(MCP)
 
 `rustbrowser-mcp` 是 stdio MCP server,暴露三個工具,Claude 呼叫即可拿到精簡內容,**原始 HTML 完全不進對話**:
@@ -277,6 +308,7 @@ CI 會執行 fmt、clippy、build、test、release build,並檢查 release binar
 - ✅ **v1.0(穩定版)** — CLI/MCP schema 凍結(+ 守門測試)· 完整安全文件(`SECURITY.md`)· semver 承諾 + `CHANGELOG.md` · CI 覆蓋 Linux/Windows/macOS · 三平台 release binaries + checksums
 - ✅ **v1.1(Actionable Observe)** — action tree(links/forms/buttons/downloads + 穩定 action_id)· MCP `observe_url` 工具 · action token 上限 · action 抽取評測。Browser Use 的第一步:RB 先能告訴 agent「這頁有哪些可操作的東西」
 - ✅ **v1.2(Session + Static Actions)** — 有狀態 session(cookie jar / current URL / redirect history / last snapshot)· MCP `session_start`/`session_observe`/`session_follow`/`session_submit_form`/`session_close` · HTML 表單提交(GET 帶 query、POST 帶 body,自動帶 hidden/selected 預設值)· 高風險(非 GET)action 需 `confirm=true` 才送 · 跨 origin 307/308 POST body 轉送會被阻擋。Browser Use 第二步:能 act,不只 observe
+- ✅ **v1.3(Action Loop)** — planner-friendly 回傳(`loop`:`state` / `available_actions` / `recommended_next_actions` / `failure_reason`)· idempotent 步驟 verify + 有限自動重試(`max_action_retries`,預設 1、上限 2;高風險 action 永不自動重試)· 操作紀錄 `operation_log`。Browser Use 第三步:把 Observe → Act → **Verify** 收成可規劃的迴圈
 
 ## 技術棧
 

--- a/README.md
+++ b/README.md
@@ -200,12 +200,12 @@ v1.2 讓 session 能 **act**;v1.3 把每次 act 的回傳整理成 **planner-fri
 
 - **`loop`** —— 規劃用的精簡視圖:
   - `state` —— 目前頁面(url / status / title / excerpt / content_chars / action_count / low_content / used_headless / steps_taken)。
-  - `available_actions` —— 把 links/forms/buttons/downloads **攤平成統一形狀**,各帶 `action_id`、`kind`、`label`、`target`、(表單的)`method` 與可填 `fields`,以及 `dangerous`(非 GET 標記)。
+  - `available_actions` —— 把 links/forms/buttons/downloads **攤平成統一形狀**,各帶 `action_id`、`kind`、`label`、`target`、(表單的)`method` 與可填 `fields`,以及 `dangerous`(非 GET 標記)。表單 `fields` 只列 caller 應填欄位;hidden/default 欄位仍由 RB 內部自動帶上。
   - `recommended_next_actions` —— 便宜誠實的啟發式提示(像是「這看起來是搜尋表單 / 下一頁連結」),指向真實 `action_id`。**只是提示,RB 不會自動執行**。
   - `failure_reason` —— 該步驟未通過 verify(HTTP 錯誤狀態)時才有;`None` 代表看起來正常。
 - **`operation_log`** —— 每步操作的除錯紀錄(step / op / target / status / attempt / outcome / failure_reason),供 debug 與改版用。
 
-**Verify + 有限自動重試**:idempotent 步驟(observe / follow / GET 表單)抓完會做 verify;遇到**可重試**的暫時性失敗(429/5xx,或暫時性連線錯誤)會再試最多 `max_action_retries` 次(預設 1,上限 2),且維持 per-host rate limit。被丟棄的重試嘗試**不會推進 session 狀態**(`redirect_history` 每次成功導航仍只記一筆)。**高風險(非 GET)提交永遠不會被自動執行,也永遠不會被自動重試。**
+**Verify + 有限自動重試**:idempotent 步驟(observe / follow / GET 表單)抓完會做 verify;遇到**可重試**的暫時性失敗(429/5xx,或暫時性連線錯誤)會再試最多 `max_action_retries` 次(預設 1,上限 2),且維持 per-host rate limit。session 內每個 loop attempt 對應一次 HTTP attempt,不會再疊加底層 fetch retry;重試之間會**指數退避**(含 jitter)並尊重伺服器的 `Retry-After`。被丟棄的重試嘗試**不會推進 session 狀態**(`redirect_history` 每次成功導航仍只記一筆)。**高風險(非 GET)提交永遠不會被自動執行,也永遠不會被自動重試。**
 
 ```jsonc
 // session_start(url, max_action_retries=2) 之後的回傳(節錄)
@@ -308,7 +308,7 @@ CI 會執行 fmt、clippy、build、test、release build,並檢查 release binar
 - ✅ **v1.0(穩定版)** — CLI/MCP schema 凍結(+ 守門測試)· 完整安全文件(`SECURITY.md`)· semver 承諾 + `CHANGELOG.md` · CI 覆蓋 Linux/Windows/macOS · 三平台 release binaries + checksums
 - ✅ **v1.1(Actionable Observe)** — action tree(links/forms/buttons/downloads + 穩定 action_id)· MCP `observe_url` 工具 · action token 上限 · action 抽取評測。Browser Use 的第一步:RB 先能告訴 agent「這頁有哪些可操作的東西」
 - ✅ **v1.2(Session + Static Actions)** — 有狀態 session(cookie jar / current URL / redirect history / last snapshot)· MCP `session_start`/`session_observe`/`session_follow`/`session_submit_form`/`session_close` · HTML 表單提交(GET 帶 query、POST 帶 body,自動帶 hidden/selected 預設值)· 高風險(非 GET)action 需 `confirm=true` 才送 · 跨 origin 307/308 POST body 轉送會被阻擋。Browser Use 第二步:能 act,不只 observe
-- ✅ **v1.3(Action Loop)** — planner-friendly 回傳(`loop`:`state` / `available_actions` / `recommended_next_actions` / `failure_reason`)· idempotent 步驟 verify + 有限自動重試(`max_action_retries`,預設 1、上限 2;高風險 action 永不自動重試)· 操作紀錄 `operation_log`。Browser Use 第三步:把 Observe → Act → **Verify** 收成可規劃的迴圈
+- ✅ **v1.3(Action Loop)** — planner-friendly 回傳(`loop`:`state` / `available_actions` / `recommended_next_actions` / `failure_reason`)· idempotent 步驟 verify + 有限自動重試(`max_action_retries`,預設 1、上限 2;每個 loop attempt 一次 HTTP attempt;高風險 action 永不自動重試)· 操作紀錄 `operation_log`。Browser Use 第三步:把 Observe → Act → **Verify** 收成可規劃的迴圈
 
 ## 技術棧
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,8 +126,11 @@ forms. The relevant safeguards:
 - **Action-Loop auto-retry is idempotent-only** — the v1.3 verify step retries a
   failed step (429/5xx or a transient transport error) only for `observe`,
   `follow`, and GET submits, up to `max_action_retries` (default 1, capped at 2).
-  A non-GET submit is **never** auto-retried or auto-executed by the loop, and a
-  discarded retry attempt never advances session state.
+  Each loop attempt is one HTTP attempt (session-level fetch retries are disabled
+  so the budget is not multiplied), and retries back off — honouring the
+  server's `Retry-After` — so the loop never hammers a host that asked it to
+  slow down. A non-GET submit is **never** auto-retried or auto-executed by the
+  loop, and a discarded retry attempt never advances session state.
 - **POST body redirects stay same-origin** — 307/308 redirects preserve method
   and body under HTTP semantics, so RB blocks cross-origin 307/308 POST
   redirects instead of forwarding submitted fields to a new origin.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -123,6 +123,11 @@ forms. The relevant safeguards:
   without an explicit go-ahead.
 - **POST is single-attempt** — a POST is never silently retried, so a
   non-idempotent action cannot be double-submitted by the retry logic.
+- **Action-Loop auto-retry is idempotent-only** — the v1.3 verify step retries a
+  failed step (429/5xx or a transient transport error) only for `observe`,
+  `follow`, and GET submits, up to `max_action_retries` (default 1, capped at 2).
+  A non-GET submit is **never** auto-retried or auto-executed by the loop, and a
+  discarded retry attempt never advances session state.
 - **POST body redirects stay same-origin** — 307/308 redirects preserve method
   and body under HTTP semantics, so RB blocks cross-origin 307/308 POST
   redirects instead of forwarding submitted fields to a new origin.

--- a/docs/API.md
+++ b/docs/API.md
@@ -109,7 +109,7 @@ it **also** carries an Action-Loop `loop` object and a debug `operation_log`
 (both additive):
 
 - `loop.state` — `{url?, status, title, excerpt?, content_chars, action_count, low_content, used_headless, steps_taken}`.
-- `loop.available_actions` — array of `{action_id, kind, label, target?, method?, dangerous?, fields?}` (links/forms/buttons/downloads flattened).
+- `loop.available_actions` — array of `{action_id, kind, label, target?, method?, dangerous?, fields?}` (links/forms/buttons/downloads flattened). For forms, `fields` lists caller-fillable names only; hidden/default fields are still carried internally when submitting.
 - `loop.recommended_next_actions` — array of `{action_id, kind, why}` (heuristic hints, never auto-executed).
 - `loop.failure_reason` — string, present only when the last step failed verification (an HTTP error status).
 - `operation_log` — recent array of `{step, op, target, status?, attempt, outcome, failure_reason?}`.
@@ -121,13 +121,15 @@ it **also** carries an Action-Loop `loop` object and a debug `operation_log`
 | `session_start` | `url` (required); `profile`, `max_actions`, `timeout_secs`, `allow_local`, `respect_robots`, `max_action_retries` | Opens `url`, returns a `session_id` + first snapshot + `loop`. |
 | `session_observe` | `session_id`, `url` | Navigate the session to `url` (keeps cookies). |
 | `session_follow` | `session_id`, `action_id` | Follow a `link_*`/`download_*` from the last snapshot. |
-| `session_submit_form` | `session_id`, `form_id`, `values` (object), `confirm` (bool) | Submit a `form_*`, merging `values` over the form's defaults. GET submits immediately; a non-GET is **withheld unless `confirm=true`** (returns `{needs_confirmation, would_submit}`). |
+| `session_submit_form` | `session_id`, `form_id`, `values` (object), `confirm` (bool) | Submit a `form_*`, merging `values` over the form's defaults. GET submits immediately; a non-GET is **withheld unless `confirm=true`** (returns the session view plus `{needs_confirmation, would_submit}`). |
 | `session_close` | `session_id` | Close a session and forget its cookies, URL, history, and snapshot. |
 
 `max_action_retries` (default `1`, clamped to `0`–`2`) gives an idempotent step
 (observe / follow / GET submit) extra attempts when it fails verification
-(429/5xx or a transient transport error). A non-GET submit is **never**
-auto-retried.
+(429/5xx or a transient transport error). In sessions, each loop attempt maps
+to one HTTP attempt; low-level fetch retries are disabled so this budget is not
+multiplied. Retries back off exponentially (with jitter) and honour the
+server's `Retry-After`. A non-GET submit is **never** auto-retried.
 
 ## JSON output schema (`Distilled`)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,17 +103,31 @@ Same parameters as `fetch_url` **except** `url`/`selector`, plus:
 
 A session keeps a cookie jar, the current URL, a redirect history, and the last
 snapshot (with its action tree). Navigation and successful submit tools return
-the session view as JSON
-(`{session_id, current_url, redirect_history, snapshot}`). `session_close`
-forgets the session and returns `{session_id, closed}`.
+the session view as JSON. The view's 1.x fields
+(`{session_id, current_url, redirect_history, snapshot}`) are stable; since 1.3
+it **also** carries an Action-Loop `loop` object and a debug `operation_log`
+(both additive):
+
+- `loop.state` — `{url?, status, title, excerpt?, content_chars, action_count, low_content, used_headless, steps_taken}`.
+- `loop.available_actions` — array of `{action_id, kind, label, target?, method?, dangerous?, fields?}` (links/forms/buttons/downloads flattened).
+- `loop.recommended_next_actions` — array of `{action_id, kind, why}` (heuristic hints, never auto-executed).
+- `loop.failure_reason` — string, present only when the last step failed verification (an HTTP error status).
+- `operation_log` — recent array of `{step, op, target, status?, attempt, outcome, failure_reason?}`.
+
+`session_close` forgets the session and returns `{session_id, closed}`.
 
 | Tool | Params | Notes |
 |---|---|---|
-| `session_start` | `url` (required); `profile`, `max_actions`, `timeout_secs`, `allow_local`, `respect_robots` | Opens `url`, returns a `session_id` + first snapshot. |
+| `session_start` | `url` (required); `profile`, `max_actions`, `timeout_secs`, `allow_local`, `respect_robots`, `max_action_retries` | Opens `url`, returns a `session_id` + first snapshot + `loop`. |
 | `session_observe` | `session_id`, `url` | Navigate the session to `url` (keeps cookies). |
 | `session_follow` | `session_id`, `action_id` | Follow a `link_*`/`download_*` from the last snapshot. |
 | `session_submit_form` | `session_id`, `form_id`, `values` (object), `confirm` (bool) | Submit a `form_*`, merging `values` over the form's defaults. GET submits immediately; a non-GET is **withheld unless `confirm=true`** (returns `{needs_confirmation, would_submit}`). |
 | `session_close` | `session_id` | Close a session and forget its cookies, URL, history, and snapshot. |
+
+`max_action_retries` (default `1`, clamped to `0`–`2`) gives an idempotent step
+(observe / follow / GET submit) extra attempts when it fails verification
+(429/5xx or a transient transport error). A non-GET submit is **never**
+auto-retried.
 
 ## JSON output schema (`Distilled`)
 

--- a/src/bin/rustbrowser-mcp.rs
+++ b/src/bin/rustbrowser-mcp.rs
@@ -114,14 +114,22 @@ impl RustBrowserServer {
     }
 }
 
-/// Serialise a session's public state (id, current URL, history, snapshot) as
-/// JSON for return to the agent.
+/// How many recent operation-log entries to include in a session view.
+const SESSION_LOG_TAIL: usize = 25;
+
+/// Serialise a session's public state as JSON for return to the agent.
+///
+/// The original 1.x fields (`session_id`, `current_url`, `redirect_history`,
+/// `snapshot`) are kept for compatibility; the Action-Loop view (`loop`) and the
+/// debug `operation_log` are **added** on top (see docs/API.md).
 fn session_view(id: &str, session: &Session) -> Result<String, rmcp::ErrorData> {
     let view = json!({
         "session_id": id,
         "current_url": session.current_url(),
         "redirect_history": session.redirect_history(),
         "snapshot": session.snapshot(),
+        "loop": session.loop_view(),
+        "operation_log": session.recent_log(SESSION_LOG_TAIL),
     });
     serde_json::to_string_pretty(&view)
         .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))
@@ -303,6 +311,11 @@ struct SessionStartParams {
     /// Respect each host's robots.txt (default false).
     #[serde(default)]
     respect_robots: Option<bool>,
+    /// Extra attempts for an idempotent step (observe/follow/GET submit) when it
+    /// fails verification — a 429/5xx or transient transport error. Clamped to
+    /// 0–2 (default 1). Non-GET submits are NEVER auto-retried.
+    #[serde(default)]
+    max_action_retries: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -669,6 +682,9 @@ impl RustBrowserServer {
         self.ensure_session_capacity()?;
         let mut session = Session::new(session_opts(&p))
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+        if let Some(n) = p.max_action_retries {
+            session = session.with_max_action_retries(n);
+        }
         session.observe(&p.url).await.map_err(|e| {
             rmcp::ErrorData::internal_error(format!("session start failed: {e}"), None)
         })?;
@@ -769,9 +785,13 @@ impl ServerHandler for RustBrowserServer {
              plus an action tree (links/forms/buttons/downloads with stable action_ids). For \
              multi-step flows use a SESSION: session_start opens a page and keeps cookies + \
              history, then session_observe / session_follow / session_submit_form drive it by \
-             action_id (GET forms submit immediately; non-GET needs confirm=true). Use \
-             session_close to forget cookies and release the session. All return clean output \
-             instead of raw HTML, saving 75-98% of tokens.",
+             action_id (GET forms submit immediately; non-GET needs confirm=true). Every session \
+             reply includes a planner-friendly `loop` view (state, available_actions, \
+             recommended_next_actions, failure_reason) and a debug `operation_log`; idempotent \
+             steps are verified and retried up to max_action_retries on a transient failure, while \
+             dangerous (non-GET) submits are never auto-executed or retried. Use session_close to \
+             forget cookies and release the session. All return clean output instead of raw HTML, \
+             saving 75-98% of tokens.",
         )
     }
 }
@@ -951,6 +971,7 @@ mod tests {
             "timeout_secs",
             "allow_local",
             "respect_robots",
+            "max_action_retries",
         ] {
             assert!(
                 start.contains(key),

--- a/src/bin/rustbrowser-mcp.rs
+++ b/src/bin/rustbrowser-mcp.rs
@@ -21,7 +21,7 @@ use rmcp::{
     transport::stdio,
 };
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Value, json};
 use tokio::sync::Mutex as AsyncMutex;
 
 use rustbrowser::session::{Session, SubmitOutcome};
@@ -122,15 +122,45 @@ const SESSION_LOG_TAIL: usize = 25;
 /// The original 1.x fields (`session_id`, `current_url`, `redirect_history`,
 /// `snapshot`) are kept for compatibility; the Action-Loop view (`loop`) and the
 /// debug `operation_log` are **added** on top (see docs/API.md).
-fn session_view(id: &str, session: &Session) -> Result<String, rmcp::ErrorData> {
-    let view = json!({
+fn session_view_value(id: &str, session: &Session) -> Value {
+    json!({
         "session_id": id,
         "current_url": session.current_url(),
         "redirect_history": session.redirect_history(),
         "snapshot": session.snapshot(),
         "loop": session.loop_view(),
         "operation_log": session.recent_log(SESSION_LOG_TAIL),
-    });
+    })
+}
+
+fn session_view(id: &str, session: &Session) -> Result<String, rmcp::ErrorData> {
+    let view = session_view_value(id, session);
+    serde_json::to_string_pretty(&view)
+        .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))
+}
+
+fn session_confirmation_view(
+    id: &str,
+    session: &Session,
+    method: String,
+    action: String,
+    fields: Vec<(String, String)>,
+) -> Result<String, rmcp::ErrorData> {
+    let mut view = session_view_value(id, session);
+    let obj = view
+        .as_object_mut()
+        .expect("session_view_value always returns a JSON object");
+    obj.insert("needs_confirmation".to_string(), json!(true));
+    obj.insert(
+        "message".to_string(),
+        json!(
+            "Dangerous (non-GET) submit withheld. Re-call session_submit_form with confirm=true to send it."
+        ),
+    );
+    obj.insert(
+        "would_submit".to_string(),
+        json!({ "method": method, "action": action, "fields": fields }),
+    );
     serde_json::to_string_pretty(&view)
         .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))
 }
@@ -762,16 +792,7 @@ impl RustBrowserServer {
                 method,
                 action,
                 fields,
-            } => {
-                let view = json!({
-                    "session_id": p.session_id,
-                    "needs_confirmation": true,
-                    "message": "Dangerous (non-GET) submit withheld. Re-call session_submit_form with confirm=true to send it.",
-                    "would_submit": { "method": method, "action": action, "fields": fields },
-                });
-                serde_json::to_string_pretty(&view)
-                    .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))
-            }
+            } => session_confirmation_view(&p.session_id, &session, method, action, fields),
         }
     }
 }
@@ -874,6 +895,27 @@ mod tests {
         assert!(!is_clean_startup_disconnect(&DisplayErr(
             "failed to bind stdio transport"
         )));
+    }
+
+    #[test]
+    fn confirmation_view_keeps_action_loop_state() {
+        let session = Session::new(DistillOptions::default()).unwrap();
+        let out = session_confirmation_view(
+            "sess_test",
+            &session,
+            "POST".to_string(),
+            "https://example.com/login".to_string(),
+            vec![("csrf".to_string(), "tok".to_string())],
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(value["session_id"], "sess_test");
+        assert_eq!(value["needs_confirmation"], true);
+        assert!(value.get("would_submit").is_some());
+        assert!(value.get("loop").is_some());
+        assert!(value.get("operation_log").is_some());
+        assert!(value.get("snapshot").is_some());
     }
 
     /// Property names present in a generated JSON schema's `properties` object.

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -430,14 +430,18 @@ impl HostGate {
 
 /// Statuses worth retrying: rate-limit and the transient server-side 5xx set.
 /// 500 is included because many gateways surface transient faults as a bare 500.
-fn is_retryable_status(status: u16) -> bool {
+/// `pub(crate)` so the session's Action-Loop verify step can reuse the exact same
+/// notion of "retryable" rather than re-deriving it.
+pub(crate) fn is_retryable_status(status: u16) -> bool {
     matches!(status, 429 | 500 | 502 | 503 | 504)
 }
 
 /// Whether an error is worth retrying: connect/timeout transport errors, but
 /// never our own SSRF block (surfaced as a `PermissionDenied` io error) and
 /// never the non-network bails (scheme, redirect cap, …).
-fn is_transient_error(e: &anyhow::Error) -> bool {
+/// `pub(crate)` so the session's Action-Loop can give an idempotent step one more
+/// try on a transient transport failure without duplicating this logic.
+pub(crate) fn is_transient_error(e: &anyhow::Error) -> bool {
     for cause in e.chain() {
         if let Some(io) = cause.downcast_ref::<std::io::Error>()
             && io.kind() == std::io::ErrorKind::PermissionDenied

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -159,6 +159,17 @@ impl Fetcher {
         self.fetch_with_retries(url, start).await
     }
 
+    /// One single HTTP attempt — no transport-level retries — returning the
+    /// result plus any `Retry-After` the server sent. The session Action Loop
+    /// drives its own bounded retry around this, so one loop attempt is exactly
+    /// one network request and the server's requested delay is still honoured
+    /// between loop attempts. Same SSRF screening and per-hop checks as `fetch`.
+    pub(crate) async fn fetch_attempt(&self, url: &str) -> Result<(FetchResult, Option<Duration>)> {
+        let start = parse_and_validate_url_basics(url, self.opts.allow_local)?;
+        let attempt = self.fetch_once(url, start, None).await?;
+        Ok((attempt.res, attempt.retry_after))
+    }
+
     /// Submit a form. `Get` appends the fields as the query string and reuses the
     /// full retried GET path; `Post` sends a urlencoded body in a **single
     /// attempt** — POST is non-idempotent and must never be silently re-sent.
@@ -328,8 +339,10 @@ pub async fn fetch(url: &str, opts: &FetchOptions) -> Result<FetchResult> {
 }
 
 /// Build `action_url` with `fields` as its query string. HTML GET-form semantics:
-/// the submitted data replaces any query already on the action URL.
-fn build_query_url(action_url: &str, fields: &[(String, String)]) -> Result<String> {
+/// the submitted data replaces any query already on the action URL. `pub(crate)`
+/// so the session's GET form submit can build the URL once and drive it through
+/// the Action Loop's verified/retried path.
+pub(crate) fn build_query_url(action_url: &str, fields: &[(String, String)]) -> Result<String> {
     let mut url =
         Url::parse(action_url).with_context(|| format!("invalid form action: {action_url}"))?;
     url.set_query(None);
@@ -458,8 +471,9 @@ pub(crate) fn is_transient_error(e: &anyhow::Error) -> bool {
 }
 
 /// Exponential backoff (base 200 ms, doubling, capped at 10 s) plus clock-seeded
-/// jitter — no RNG dependency needed for a backoff delay.
-fn backoff_delay(attempt: usize) -> Duration {
+/// jitter — no RNG dependency needed for a backoff delay. `pub(crate)` so the
+/// session's Action Loop backs off identically between its own retries.
+pub(crate) fn backoff_delay(attempt: usize) -> Duration {
     let base_ms = 200u64.saturating_mul(1u64 << attempt.min(6)).min(10_000);
     Duration::from_millis(base_ms + jitter_ms(base_ms))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cache;
 pub mod convert;
 pub mod extract;
 pub mod fetch;
+pub mod planner;
 pub mod render;
 #[cfg(feature = "robots")]
 pub mod robots;

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -49,7 +49,8 @@ pub struct PageState {
     pub low_content: bool,
     /// Headless rendering was used for this page.
     pub used_headless: bool,
-    /// How many session steps have been taken so far (logged operations).
+    /// How many operations (observe / follow / submit_form) the session has
+    /// run so far. Retry attempts within an operation do not add steps.
     pub steps_taken: usize,
 }
 
@@ -87,7 +88,8 @@ pub struct AvailableAction {
     /// (non-GET form submits). Such actions are never auto-executed or retried.
     #[serde(skip_serializing_if = "is_false")]
     pub dangerous: bool,
-    /// For forms: the field names a caller may fill.
+    /// For forms: field names a caller may fill. Hidden/default-only controls
+    /// are intentionally omitted; RB still carries their defaults internally.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<String>,
 }
@@ -103,7 +105,8 @@ pub struct RecommendedAction {
 /// One recorded operation in a session's debug log.
 #[derive(Debug, Clone, Serialize)]
 pub struct OpLogEntry {
-    /// Monotonic step counter within the session.
+    /// The logical operation this entry belongs to (1-based, monotonic).
+    /// Retries of the same operation share a step; `attempt` tells them apart.
     pub step: usize,
     /// `observe`, `follow`, or `submit_form`.
     pub op: String,
@@ -195,7 +198,12 @@ fn flatten_actions(tree: &ActionTree) -> Vec<AvailableAction> {
             target: Some(f.action.clone()),
             method: Some(f.method.clone()),
             dangerous: is_dangerous_method(&f.method),
-            fields: f.fields.iter().map(|fl| fl.name.clone()).collect(),
+            fields: f
+                .fields
+                .iter()
+                .filter(|fl| is_fillable_field(&fl.name, &fl.kind))
+                .map(|fl| fl.name.clone())
+                .collect(),
         });
     }
     for b in &tree.buttons {
@@ -224,8 +232,9 @@ fn flatten_actions(tree: &ActionTree) -> Vec<AvailableAction> {
     out
 }
 
-/// Cheap, honest "what next" hints pointing at real `action_id`s. At most three:
-/// a GET search/filter form, a pagination/next link, then the first link.
+/// Cheap, honest "what next" hints pointing at real `action_id`s. At most two:
+/// a GET search/filter form and/or a pagination/next link, falling back to the
+/// first link only when neither matched.
 fn recommend(tree: &ActionTree) -> Vec<RecommendedAction> {
     let mut recs = Vec::new();
 
@@ -265,6 +274,16 @@ fn recommend(tree: &ActionTree) -> Vec<RecommendedAction> {
 /// Anything other than GET is a "dangerous" action RB will not run unconfirmed.
 fn is_dangerous_method(method: &str) -> bool {
     !method.eq_ignore_ascii_case("GET")
+}
+
+fn is_fillable_field(name: &str, kind: &str) -> bool {
+    if name.trim().is_empty() {
+        return false;
+    }
+    !matches!(
+        kind.to_ascii_lowercase().as_str(),
+        "hidden" | "submit" | "button" | "reset" | "image"
+    )
 }
 
 fn form_looks_searchy(form: &FormAction) -> bool {
@@ -349,7 +368,13 @@ mod tests {
                     method: "POST".to_string(),
                     action: "https://e.com/login".to_string(),
                     submit_id: "form_1.submit".to_string(),
-                    fields: vec![field("user", "text"), field("pass", "password")],
+                    fields: vec![
+                        field("csrf", "hidden"),
+                        field("user", "text"),
+                        field("pass", "password"),
+                        field("submit", "submit"),
+                        field("", "text"),
+                    ],
                 },
             ],
             buttons: vec![ButtonAction {

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1,0 +1,432 @@
+//! Planner-friendly view for the **RB Action Loop** (Observe → Act → Verify).
+//!
+//! A `Session` produces a [`LoopView`] after every step so an LLM planner can
+//! decide what to do next from a compact, uniform shape rather than re-reading a
+//! raw `Distilled` blob:
+//!
+//! - `state` — the current page (url/status/title/excerpt + a few health flags).
+//! - `available_actions` — every operable element flattened to one shape, each
+//!   with its stable `action_id`, a `kind`, a human `label`, and (for forms) the
+//!   `method`, fillable `fields`, and whether it is `dangerous` (non-GET).
+//! - `recommended_next_actions` — cheap, honest heuristics ("this looks like a
+//!   search form / a next-page link") pointing at real `action_id`s. These are
+//!   *hints*, never executed automatically.
+//! - `failure_reason` — set when the last step did not verify (an HTTP error
+//!   status). `None` means the step looked OK.
+//!
+//! The view is built from data already in the snapshot; it never fetches.
+
+use serde::Serialize;
+
+use crate::Distilled;
+use crate::actions::{ActionTree, FormAction};
+
+/// A planner-friendly snapshot of the session after one Observe/Act step.
+#[derive(Debug, Clone, Serialize)]
+pub struct LoopView {
+    pub state: PageState,
+    pub available_actions: Vec<AvailableAction>,
+    pub recommended_next_actions: Vec<RecommendedAction>,
+    /// Why the last step failed verification (HTTP error). `None` = looks OK.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+}
+
+/// The current page state — the "where am I" half of the loop.
+#[derive(Debug, Clone, Serialize)]
+pub struct PageState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub status: u16,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excerpt: Option<String>,
+    /// Characters of distilled Markdown on this page.
+    pub content_chars: usize,
+    /// Total operable actions found.
+    pub action_count: usize,
+    /// The distilled content is suspiciously short (possible JS-only page).
+    pub low_content: bool,
+    /// Headless rendering was used for this page.
+    pub used_headless: bool,
+    /// How many session steps have been taken so far (logged operations).
+    pub steps_taken: usize,
+}
+
+impl PageState {
+    fn empty(steps_taken: usize) -> Self {
+        Self {
+            url: None,
+            status: 0,
+            title: String::new(),
+            excerpt: None,
+            content_chars: 0,
+            action_count: 0,
+            low_content: false,
+            used_headless: false,
+            steps_taken,
+        }
+    }
+}
+
+/// One operable element, flattened to a single uniform shape for the planner.
+#[derive(Debug, Clone, Serialize)]
+pub struct AvailableAction {
+    pub action_id: String,
+    /// `link`, `form`, `button`, or `download`.
+    pub kind: String,
+    /// Human-readable label (link text, form summary, button caption, …).
+    pub label: String,
+    /// Target URL for links/downloads; the submit URL for forms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// `GET`/`POST` for forms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// True for actions RB will not run without explicit confirmation
+    /// (non-GET form submits). Such actions are never auto-executed or retried.
+    #[serde(skip_serializing_if = "is_false")]
+    pub dangerous: bool,
+    /// For forms: the field names a caller may fill.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<String>,
+}
+
+/// A heuristic suggestion. A hint for the planner — never executed by RB itself.
+#[derive(Debug, Clone, Serialize)]
+pub struct RecommendedAction {
+    pub action_id: String,
+    pub kind: String,
+    pub why: String,
+}
+
+/// One recorded operation in a session's debug log.
+#[derive(Debug, Clone, Serialize)]
+pub struct OpLogEntry {
+    /// Monotonic step counter within the session.
+    pub step: usize,
+    /// `observe`, `follow`, or `submit_form`.
+    pub op: String,
+    /// The URL or form action the operation targeted.
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    /// 1-based attempt number for this operation (0 = not attempted, e.g. a
+    /// non-GET submit withheld pending confirmation).
+    pub attempt: usize,
+    /// `ok`, `verify_failed`, `retryable_status`, `transient_error_retry`,
+    /// `error`, `distill_failed`, or `needs_confirmation`.
+    pub outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+}
+
+/// The **Verify** step: decide whether a freshly recorded snapshot represents a
+/// failed step. Today that is purely an HTTP error status — sparse content is a
+/// soft signal surfaced via `PageState.low_content`, not a hard failure (a short
+/// page is often legitimate, so it must not be treated as an error or retried).
+pub fn verify(snapshot: &Distilled) -> Option<String> {
+    status_failure(snapshot.status)
+}
+
+fn status_failure(status: u16) -> Option<String> {
+    (status >= 400).then(|| format!("http_status_{status}"))
+}
+
+/// Build the planner view from the last snapshot (if any), the last verify
+/// result, and how many steps have been taken. Pure — never fetches.
+pub fn loop_view(
+    snapshot: Option<&Distilled>,
+    failure_reason: Option<String>,
+    steps_taken: usize,
+) -> LoopView {
+    let Some(snap) = snapshot else {
+        return LoopView {
+            state: PageState::empty(steps_taken),
+            available_actions: Vec::new(),
+            recommended_next_actions: Vec::new(),
+            failure_reason,
+        };
+    };
+
+    let tree = snap.actions.as_ref();
+    let available_actions = tree.map(flatten_actions).unwrap_or_default();
+    let recommended_next_actions = tree.map(recommend).unwrap_or_default();
+    let diag = snap.diagnostics.as_ref();
+
+    LoopView {
+        state: PageState {
+            url: Some(snap.final_url.clone()),
+            status: snap.status,
+            title: snap.title.clone(),
+            excerpt: snap.excerpt.clone(),
+            content_chars: snap.markdown.chars().count(),
+            action_count: tree.map_or(0, ActionTree::len),
+            low_content: diag.is_some_and(|d| d.low_content),
+            used_headless: diag.is_some_and(|d| d.used_headless),
+            steps_taken,
+        },
+        available_actions,
+        recommended_next_actions,
+        failure_reason,
+    }
+}
+
+/// Flatten the categorised action tree into one uniform list, preserving each
+/// element's stable `action_id`.
+fn flatten_actions(tree: &ActionTree) -> Vec<AvailableAction> {
+    let mut out = Vec::with_capacity(tree.len());
+    for l in &tree.links {
+        out.push(AvailableAction {
+            action_id: l.action_id.clone(),
+            kind: "link".to_string(),
+            label: label_or(&l.text, &l.href),
+            target: Some(l.href.clone()),
+            method: None,
+            dangerous: false,
+            fields: Vec::new(),
+        });
+    }
+    for f in &tree.forms {
+        out.push(AvailableAction {
+            action_id: f.action_id.clone(),
+            kind: "form".to_string(),
+            label: format!("{} form → {}", f.method, f.action),
+            target: Some(f.action.clone()),
+            method: Some(f.method.clone()),
+            dangerous: is_dangerous_method(&f.method),
+            fields: f.fields.iter().map(|fl| fl.name.clone()).collect(),
+        });
+    }
+    for b in &tree.buttons {
+        out.push(AvailableAction {
+            action_id: b.action_id.clone(),
+            kind: "button".to_string(),
+            label: b.text.clone(),
+            target: None,
+            method: None,
+            dangerous: false,
+            fields: Vec::new(),
+        });
+    }
+    for d in &tree.downloads {
+        let fallback = d.filename.as_deref().unwrap_or(&d.href);
+        out.push(AvailableAction {
+            action_id: d.action_id.clone(),
+            kind: "download".to_string(),
+            label: label_or(&d.text, fallback),
+            target: Some(d.href.clone()),
+            method: None,
+            dangerous: false,
+            fields: Vec::new(),
+        });
+    }
+    out
+}
+
+/// Cheap, honest "what next" hints pointing at real `action_id`s. At most three:
+/// a GET search/filter form, a pagination/next link, then the first link.
+fn recommend(tree: &ActionTree) -> Vec<RecommendedAction> {
+    let mut recs = Vec::new();
+
+    if let Some(f) = tree
+        .forms
+        .iter()
+        .find(|f| !is_dangerous_method(&f.method) && form_looks_searchy(f))
+    {
+        recs.push(RecommendedAction {
+            action_id: f.action_id.clone(),
+            kind: "form".to_string(),
+            why: "search/filter form (GET) — submit it to query the site".to_string(),
+        });
+    }
+
+    if let Some(l) = tree.links.iter().find(|l| link_looks_paginated(&l.text)) {
+        recs.push(RecommendedAction {
+            action_id: l.action_id.clone(),
+            kind: "link".to_string(),
+            why: "looks like pagination / next — follow it to walk the list".to_string(),
+        });
+    }
+
+    if recs.is_empty()
+        && let Some(l) = tree.links.first()
+    {
+        recs.push(RecommendedAction {
+            action_id: l.action_id.clone(),
+            kind: "link".to_string(),
+            why: "primary link on the page — follow it to navigate".to_string(),
+        });
+    }
+
+    recs
+}
+
+/// Anything other than GET is a "dangerous" action RB will not run unconfirmed.
+fn is_dangerous_method(method: &str) -> bool {
+    !method.eq_ignore_ascii_case("GET")
+}
+
+fn form_looks_searchy(form: &FormAction) -> bool {
+    form.fields.iter().any(|f| {
+        let kind = f.kind.to_ascii_lowercase();
+        let name = f.name.to_ascii_lowercase();
+        kind == "search"
+            || name == "q"
+            || ["query", "search", "keyword", "term", "find"]
+                .iter()
+                .any(|s| name.contains(s))
+    })
+}
+
+fn link_looks_paginated(text: &str) -> bool {
+    let t = text.trim().to_ascii_lowercase();
+    if t == ">" || t == ">>" {
+        return true;
+    }
+    ["next", "more", "older", "newer", "›", "»", "→"]
+        .iter()
+        .any(|s| t.contains(s))
+}
+
+fn label_or(text: &str, fallback: &str) -> String {
+    if text.trim().is_empty() {
+        fallback.to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::{ButtonAction, DownloadAction, FormField, FormOption, LinkAction};
+
+    fn link(id: &str, text: &str, href: &str) -> LinkAction {
+        LinkAction {
+            action_id: id.to_string(),
+            text: text.to_string(),
+            href: href.to_string(),
+        }
+    }
+
+    fn field(name: &str, kind: &str) -> FormField {
+        FormField {
+            name: name.to_string(),
+            kind: kind.to_string(),
+            value: None,
+            options: Vec::<FormOption>::new(),
+            required: false,
+        }
+    }
+
+    #[test]
+    fn status_failure_flags_only_4xx_5xx() {
+        assert_eq!(status_failure(200), None);
+        assert_eq!(status_failure(301), None);
+        assert_eq!(status_failure(404).as_deref(), Some("http_status_404"));
+        assert_eq!(status_failure(503).as_deref(), Some("http_status_503"));
+    }
+
+    #[test]
+    fn flatten_marks_non_get_forms_dangerous_and_lists_fields() {
+        let tree = ActionTree {
+            links: vec![link("link_0", "About", "https://e.com/about")],
+            forms: vec![
+                FormAction {
+                    action_id: "form_0".to_string(),
+                    method: "GET".to_string(),
+                    action: "https://e.com/search".to_string(),
+                    submit_id: "form_0.submit".to_string(),
+                    fields: vec![field("q", "search")],
+                },
+                FormAction {
+                    action_id: "form_1".to_string(),
+                    method: "POST".to_string(),
+                    action: "https://e.com/login".to_string(),
+                    submit_id: "form_1.submit".to_string(),
+                    fields: vec![field("user", "text"), field("pass", "password")],
+                },
+            ],
+            buttons: vec![ButtonAction {
+                action_id: "button_0".to_string(),
+                text: "Load more".to_string(),
+                kind: "button".to_string(),
+            }],
+            downloads: vec![DownloadAction {
+                action_id: "download_0".to_string(),
+                text: String::new(),
+                href: "https://e.com/report.pdf".to_string(),
+                filename: Some("report.pdf".to_string()),
+            }],
+        };
+
+        let flat = flatten_actions(&tree);
+        assert_eq!(flat.len(), 5);
+
+        let get_form = flat.iter().find(|a| a.action_id == "form_0").unwrap();
+        assert!(!get_form.dangerous);
+        assert_eq!(get_form.method.as_deref(), Some("GET"));
+
+        let post_form = flat.iter().find(|a| a.action_id == "form_1").unwrap();
+        assert!(post_form.dangerous, "non-GET form must be dangerous");
+        assert_eq!(post_form.fields, vec!["user", "pass"]);
+
+        // Empty link/download text falls back to a useful label.
+        let dl = flat.iter().find(|a| a.action_id == "download_0").unwrap();
+        assert_eq!(dl.label, "report.pdf");
+    }
+
+    #[test]
+    fn recommend_prefers_search_form_then_pagination_then_first_link() {
+        let searchy = ActionTree {
+            links: vec![link("link_0", "Home", "https://e.com/")],
+            forms: vec![FormAction {
+                action_id: "form_0".to_string(),
+                method: "GET".to_string(),
+                action: "https://e.com/search".to_string(),
+                submit_id: "form_0.submit".to_string(),
+                fields: vec![field("q", "search")],
+            }],
+            buttons: Vec::new(),
+            downloads: Vec::new(),
+        };
+        let recs = recommend(&searchy);
+        assert_eq!(recs[0].action_id, "form_0");
+        assert_eq!(recs[0].kind, "form");
+
+        let paginated = ActionTree {
+            links: vec![
+                link("link_0", "Article", "https://e.com/a"),
+                link("link_1", "Next ›", "https://e.com/p2"),
+            ],
+            forms: Vec::new(),
+            buttons: Vec::new(),
+            downloads: Vec::new(),
+        };
+        let recs = recommend(&paginated);
+        assert_eq!(recs[0].action_id, "link_1", "pagination link preferred");
+
+        let plain = ActionTree {
+            links: vec![link("link_0", "Read", "https://e.com/read")],
+            forms: Vec::new(),
+            buttons: Vec::new(),
+            downloads: Vec::new(),
+        };
+        let recs = recommend(&plain);
+        assert_eq!(recs[0].action_id, "link_0");
+    }
+
+    #[test]
+    fn empty_snapshot_yields_empty_view() {
+        let v = loop_view(None, Some("boom".to_string()), 3);
+        assert_eq!(v.state.status, 0);
+        assert_eq!(v.state.steps_taken, 3);
+        assert!(v.available_actions.is_empty());
+        assert_eq!(v.failure_reason.as_deref(), Some("boom"));
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,19 +1,36 @@
-//! Stateful browsing session for Browser Use (Observe → Act → Verify).
+//! Stateful browsing session for the **RB Action Loop** (Observe → Act → Verify).
 //!
-//! A `Session` keeps a cookie jar, the current URL, a redirect history, and the
-//! last observed snapshot (distilled content + action tree). An agent drives it
-//! by `observe`-ing a URL, then `follow`-ing a link or `submit_form`-ing by the
-//! stable `action_id`s in the last snapshot — never opening a real browser.
+//! A `Session` keeps a cookie jar, the current URL, a redirect history, the last
+//! observed snapshot (distilled content + action tree), and a debug log of every
+//! operation. An agent drives it by `observe`-ing a URL, then `follow`-ing a link
+//! or `submit_form`-ing by the stable `action_id`s in the last snapshot — never
+//! opening a real browser. After each step, [`Session::loop_view`] yields a
+//! compact, planner-friendly view (state + available/recommended actions +
+//! failure reason).
+//!
+//! Verify & retry: after an idempotent step (observe / follow / GET submit) the
+//! snapshot is verified; a *retryable* failure (429/5xx, or a transient transport
+//! error) is given up to `max_action_retries` more attempts. A non-GET submit is
+//! a *dangerous* action: it is refused unless the caller confirms, and is **never
+//! retried** — RB never silently re-sends a POST.
 //!
 //! Safety: every request reuses the same SSRF-screened path as plain fetches.
-//! A non-GET form submit is a *dangerous* action and is refused unless the
-//! caller explicitly confirms — RB never silently POSTs on an agent's behalf.
 
 use anyhow::{Context, Result, anyhow, bail};
 
 use crate::actions::FormAction;
 use crate::fetch::{FetchOptions, FetchResult, Fetcher, SubmitMethod};
+use crate::planner::{self, LoopView, OpLogEntry};
 use crate::{DistillOptions, Distilled, distill_html};
+
+/// Default extra attempts for an idempotent step whose verify failed.
+const DEFAULT_MAX_ACTION_RETRIES: usize = 1;
+/// Hard ceiling on auto-retries (roadmap: "at most 1–2").
+const MAX_ACTION_RETRIES_CAP: usize = 2;
+/// Keep at most this many operation-log entries (most recent win).
+const MAX_LOG_ENTRIES: usize = 200;
+/// Truncate a logged error message to this many characters.
+const MAX_LOGGED_ERR_CHARS: usize = 200;
 
 /// A stateful browsing session.
 pub struct Session {
@@ -23,6 +40,14 @@ pub struct Session {
     current_url: Option<String>,
     redirect_history: Vec<String>,
     last_snapshot: Option<Distilled>,
+    /// Extra attempts for an idempotent step that fails verification.
+    max_action_retries: usize,
+    /// Verify result of the most recent step (`None` = looked OK).
+    last_failure: Option<String>,
+    /// Operation log for debugging the loop.
+    log: Vec<OpLogEntry>,
+    /// Monotonic step counter (also the number of logged operations).
+    step: usize,
 }
 
 /// What happened when a form submit was requested.
@@ -36,6 +61,17 @@ pub enum SubmitOutcome {
         method: String,
         action: String,
         fields: Vec<(String, String)>,
+    },
+}
+
+/// How to perform one idempotent fetch inside the verify/retry loop.
+enum Step<'a> {
+    /// Plain GET of a URL (observe / follow).
+    Get(&'a str),
+    /// GET form submit: fields become the query string.
+    SubmitGet {
+        action: &'a str,
+        fields: &'a [(String, String)],
     },
 }
 
@@ -58,10 +94,11 @@ impl Session {
             fopts.user_agent = ua.clone();
         }
 
-        // Snapshots always carry the action tree; caching is off so a session
-        // always sees live state.
+        // Snapshots always carry the action tree and diagnostics; caching is off
+        // so a session always sees live state.
         let mut snapshot_opts = opts;
         snapshot_opts.extract_actions = true;
+        snapshot_opts.diagnostics = true;
         snapshot_opts.use_cache = false;
 
         Ok(Self {
@@ -70,7 +107,18 @@ impl Session {
             current_url: None,
             redirect_history: Vec::new(),
             last_snapshot: None,
+            max_action_retries: DEFAULT_MAX_ACTION_RETRIES,
+            last_failure: None,
+            log: Vec::new(),
+            step: 0,
         })
+    }
+
+    /// Set how many extra attempts an idempotent step gets when verification
+    /// fails (clamped to the roadmap's 0–2). Non-GET submits are never retried.
+    pub fn with_max_action_retries(mut self, n: usize) -> Self {
+        self.max_action_retries = n.min(MAX_ACTION_RETRIES_CAP);
+        self
     }
 
     pub fn current_url(&self) -> Option<&str> {
@@ -85,24 +133,50 @@ impl Session {
         self.last_snapshot.as_ref()
     }
 
-    /// Fetch `url` and make it the current snapshot.
-    pub async fn observe(&mut self, url: &str) -> Result<&Distilled> {
-        let result = self.fetcher.fetch(url).await?;
-        self.record(result)?;
-        self.snapshot_ref()
+    /// The verify result of the most recent step (`None` = looked OK).
+    pub fn last_failure(&self) -> Option<&str> {
+        self.last_failure.as_deref()
     }
 
-    /// Follow a `link_*` / `download_*` action from the last snapshot.
+    /// The full operation log.
+    pub fn log(&self) -> &[OpLogEntry] {
+        &self.log
+    }
+
+    /// The most recent `n` operation-log entries.
+    pub fn recent_log(&self, n: usize) -> &[OpLogEntry] {
+        let start = self.log.len().saturating_sub(n);
+        &self.log[start..]
+    }
+
+    /// A compact, planner-friendly view of the current state, available actions,
+    /// recommended next actions, and any failure reason.
+    pub fn loop_view(&self) -> LoopView {
+        planner::loop_view(
+            self.last_snapshot.as_ref(),
+            self.last_failure.clone(),
+            self.step,
+        )
+    }
+
+    /// Fetch `url` and make it the current snapshot (idempotent: verified +
+    /// retried on a transient failure).
+    pub async fn observe(&mut self, url: &str) -> Result<&Distilled> {
+        self.run_idempotent("observe", url.to_string(), Step::Get(url))
+            .await
+    }
+
+    /// Follow a `link_*` / `download_*` action from the last snapshot
+    /// (idempotent: verified + retried on a transient failure).
     pub async fn follow(&mut self, action_id: &str) -> Result<&Distilled> {
         let href = self.resolve_followable(action_id)?;
-        let result = self.fetcher.fetch(&href).await?;
-        self.record(result)?;
-        self.snapshot_ref()
+        self.run_idempotent("follow", href.clone(), Step::Get(&href))
+            .await
     }
 
     /// Submit a `form_*` from the last snapshot, merging the form's own default
     /// values (hidden fields, selected options) with the caller's `values`.
-    /// A non-GET submit requires `confirm = true`.
+    /// A non-GET submit requires `confirm = true` and is never auto-retried.
     pub async fn submit_form(
         &mut self,
         form_id: &str,
@@ -119,6 +193,14 @@ impl Session {
 
         // Non-GET is a dangerous action: never auto-execute without confirmation.
         if method != SubmitMethod::Get && !confirm {
+            self.log_attempt(
+                "submit_form",
+                &form.action,
+                None,
+                0,
+                "needs_confirmation",
+                None,
+            );
             return Ok(SubmitOutcome::NeedsConfirmation {
                 method: form.method.clone(),
                 action: form.action.clone(),
@@ -126,21 +208,202 @@ impl Session {
             });
         }
 
-        let result = self.fetcher.submit(&form.action, method, &fields).await?;
-        self.record(result)?;
+        // GET form submit is idempotent: verify + limited retry like observe.
+        if method == SubmitMethod::Get {
+            self.run_idempotent(
+                "submit_form",
+                form.action.clone(),
+                Step::SubmitGet {
+                    action: &form.action,
+                    fields: &fields,
+                },
+            )
+            .await?;
+            return Ok(SubmitOutcome::Submitted);
+        }
+
+        // Confirmed non-GET: a single attempt, never silently retried.
+        let result = match self.fetcher.submit(&form.action, method, &fields).await {
+            Ok(r) => r,
+            Err(e) => {
+                self.log_attempt(
+                    "submit_form",
+                    &form.action,
+                    None,
+                    1,
+                    "error",
+                    Some(short_err(&e)),
+                );
+                return Err(e);
+            }
+        };
+        let status = result.status;
+        if let Err(e) = self.record(result) {
+            self.log_attempt(
+                "submit_form",
+                &form.action,
+                Some(status),
+                1,
+                "distill_failed",
+                Some(short_err(&e)),
+            );
+            return Err(e);
+        }
+        let failure = self.last_snapshot.as_ref().and_then(planner::verify);
+        self.last_failure = failure.clone();
+        self.commit_navigation();
+        self.log_attempt(
+            "submit_form",
+            &form.action,
+            Some(status),
+            1,
+            outcome_label(&failure),
+            failure,
+        );
         Ok(SubmitOutcome::Submitted)
     }
 
+    /// Run an idempotent step with verify + bounded retry. Only the result we
+    /// actually keep is recorded, so a discarded retryable attempt never advances
+    /// session state, and `redirect_history` gets one entry per settled
+    /// navigation.
+    async fn run_idempotent(
+        &mut self,
+        op: &str,
+        target: String,
+        step: Step<'_>,
+    ) -> Result<&Distilled> {
+        let mut attempt = 0usize;
+        loop {
+            match self.do_fetch(&step).await {
+                Ok(result) => {
+                    let status = result.status;
+                    // Server said "try later" and we still have budget: discard
+                    // this response (don't advance state) and retry.
+                    if attempt < self.max_action_retries
+                        && crate::fetch::is_retryable_status(status)
+                    {
+                        self.log_attempt(
+                            op,
+                            &target,
+                            Some(status),
+                            attempt + 1,
+                            "retryable_status",
+                            Some(format!("http_status_{status}")),
+                        );
+                        attempt += 1;
+                        continue;
+                    }
+                    // Keep this result. record() is atomic: on a distill failure
+                    // it returns Err without mutating state.
+                    if let Err(e) = self.record(result) {
+                        self.log_attempt(
+                            op,
+                            &target,
+                            Some(status),
+                            attempt + 1,
+                            "distill_failed",
+                            Some(short_err(&e)),
+                        );
+                        return Err(e);
+                    }
+                    let failure = self.last_snapshot.as_ref().and_then(planner::verify);
+                    self.last_failure = failure.clone();
+                    self.commit_navigation();
+                    self.log_attempt(
+                        op,
+                        &target,
+                        Some(status),
+                        attempt + 1,
+                        outcome_label(&failure),
+                        failure,
+                    );
+                    return self.snapshot_ref();
+                }
+                Err(e) => {
+                    // A transient transport error (the fetcher already exhausted
+                    // its own transport retries) gets one more whole-step try.
+                    let retry =
+                        attempt < self.max_action_retries && crate::fetch::is_transient_error(&e);
+                    self.log_attempt(
+                        op,
+                        &target,
+                        None,
+                        attempt + 1,
+                        if retry {
+                            "transient_error_retry"
+                        } else {
+                            "error"
+                        },
+                        Some(short_err(&e)),
+                    );
+                    if retry {
+                        attempt += 1;
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Perform one fetch for a [`Step`]. Borrows only the client, so the caller
+    /// can mutate session state with the owned result afterwards.
+    async fn do_fetch(&self, step: &Step<'_>) -> Result<FetchResult> {
+        match step {
+            Step::Get(url) => self.fetcher.fetch(url).await,
+            Step::SubmitGet { action, fields } => {
+                self.fetcher.submit(action, SubmitMethod::Get, fields).await
+            }
+        }
+    }
+
+    /// Distill `result` into the current snapshot. Atomic: distills first, then
+    /// mutates, so a distill failure leaves the previous snapshot/URL intact.
+    /// Does **not** touch `redirect_history` — that is committed once per settled
+    /// navigation by [`Session::commit_navigation`].
     fn record(&mut self, result: FetchResult) -> Result<()> {
         let mut snap = distill_html(&result.html, &result.final_url, &self.opts)
             .with_context(|| format!("distilling session snapshot for {}", result.final_url))?;
         // distill_html stamps a synthetic 200; carry the real HTTP status.
         snap.status = result.status;
 
-        self.current_url = Some(result.final_url.clone());
-        self.redirect_history.push(result.final_url);
+        self.current_url = Some(result.final_url);
         self.last_snapshot = Some(snap);
         Ok(())
+    }
+
+    /// Record the settled current URL in the redirect history (one entry per
+    /// successful navigation, not per retry attempt).
+    fn commit_navigation(&mut self) {
+        if let Some(url) = self.current_url.clone() {
+            self.redirect_history.push(url);
+        }
+    }
+
+    fn log_attempt(
+        &mut self,
+        op: &str,
+        target: &str,
+        status: Option<u16>,
+        attempt: usize,
+        outcome: &str,
+        failure_reason: Option<String>,
+    ) {
+        self.step += 1;
+        self.log.push(OpLogEntry {
+            step: self.step,
+            op: op.to_string(),
+            target: target.to_string(),
+            status,
+            attempt,
+            outcome: outcome.to_string(),
+            failure_reason,
+        });
+        if self.log.len() > MAX_LOG_ENTRIES {
+            let drop = self.log.len() - MAX_LOG_ENTRIES;
+            self.log.drain(0..drop);
+        }
     }
 
     fn snapshot_ref(&self) -> Result<&Distilled> {
@@ -172,6 +435,26 @@ impl Session {
             .and_then(|a| a.forms.iter().find(|f| f.action_id == form_id))
             .cloned()
             .ok_or_else(|| anyhow!("no form '{form_id}' in the current snapshot"))
+    }
+}
+
+/// Map a verify result to an operation-log outcome label.
+fn outcome_label(failure: &Option<String>) -> &'static str {
+    if failure.is_some() {
+        "verify_failed"
+    } else {
+        "ok"
+    }
+}
+
+/// Render an error chain to a single bounded line for the operation log.
+fn short_err(e: &anyhow::Error) -> String {
+    let s = format!("{e:#}");
+    if s.chars().count() > MAX_LOGGED_ERR_CHARS {
+        let head: String = s.chars().take(MAX_LOGGED_ERR_CHARS).collect();
+        format!("{head}…")
+    } else {
+        s
     }
 }
 
@@ -264,5 +547,12 @@ mod tests {
         let csrf: Vec<_> = merged.iter().filter(|(k, _)| k == "csrf").collect();
         assert_eq!(csrf.len(), 1);
         assert_eq!(csrf[0].1, "evil");
+    }
+
+    #[test]
+    fn max_action_retries_is_clamped() {
+        let opts = DistillOptions::default();
+        let s = Session::new(opts).unwrap().with_max_action_retries(99);
+        assert_eq!(s.max_action_retries, MAX_ACTION_RETRIES_CAP);
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,9 +17,10 @@
 //! Safety: every request reuses the same SSRF-screened path as plain fetches.
 
 use anyhow::{Context, Result, anyhow, bail};
+use tokio::time::sleep;
 
 use crate::actions::FormAction;
-use crate::fetch::{FetchOptions, FetchResult, Fetcher, SubmitMethod};
+use crate::fetch::{self, FetchOptions, FetchResult, Fetcher, SubmitMethod};
 use crate::planner::{self, LoopView, OpLogEntry};
 use crate::{DistillOptions, Distilled, distill_html};
 
@@ -46,7 +47,8 @@ pub struct Session {
     last_failure: Option<String>,
     /// Operation log for debugging the loop.
     log: Vec<OpLogEntry>,
-    /// Monotonic step counter (also the number of logged operations).
+    /// Logical operation counter: one per observe/follow/submit_form call.
+    /// Every log entry an operation produces (retries included) shares it.
     step: usize,
 }
 
@@ -64,17 +66,6 @@ pub enum SubmitOutcome {
     },
 }
 
-/// How to perform one idempotent fetch inside the verify/retry loop.
-enum Step<'a> {
-    /// Plain GET of a URL (observe / follow).
-    Get(&'a str),
-    /// GET form submit: fields become the query string.
-    SubmitGet {
-        action: &'a str,
-        fields: &'a [(String, String)],
-    },
-}
-
 impl Session {
     /// Start a session. The given options seed every snapshot; cookies persist
     /// across requests and the action tree is always extracted.
@@ -83,7 +74,10 @@ impl Session {
             timeout: opts.timeout,
             max_bytes: opts.max_bytes,
             allow_local: opts.allow_local,
-            max_retries: opts.max_retries,
+            // The Action Loop owns the per-step retry budget. Keep each loop
+            // attempt to one HTTP attempt so `max_action_retries` maps directly
+            // to actual network retries.
+            max_retries: 0,
             per_host_concurrency: opts.per_host_concurrency,
             min_request_interval: opts.min_request_interval,
             respect_robots: opts.respect_robots,
@@ -162,16 +156,14 @@ impl Session {
     /// Fetch `url` and make it the current snapshot (idempotent: verified +
     /// retried on a transient failure).
     pub async fn observe(&mut self, url: &str) -> Result<&Distilled> {
-        self.run_idempotent("observe", url.to_string(), Step::Get(url))
-            .await
+        self.run_idempotent("observe", url.to_string(), url).await
     }
 
     /// Follow a `link_*` / `download_*` action from the last snapshot
     /// (idempotent: verified + retried on a transient failure).
     pub async fn follow(&mut self, action_id: &str) -> Result<&Distilled> {
         let href = self.resolve_followable(action_id)?;
-        self.run_idempotent("follow", href.clone(), Step::Get(&href))
-            .await
+        self.run_idempotent("follow", href.clone(), &href).await
     }
 
     /// Submit a `form_*` from the last snapshot, merging the form's own default
@@ -193,6 +185,7 @@ impl Session {
 
         // Non-GET is a dangerous action: never auto-execute without confirmation.
         if method != SubmitMethod::Get && !confirm {
+            self.begin_step();
             self.log_attempt(
                 "submit_form",
                 &form.action,
@@ -208,21 +201,17 @@ impl Session {
             });
         }
 
-        // GET form submit is idempotent: verify + limited retry like observe.
+        // GET form submit is idempotent: the fields become the query string and
+        // the step is verified + retried like an observe.
         if method == SubmitMethod::Get {
-            self.run_idempotent(
-                "submit_form",
-                form.action.clone(),
-                Step::SubmitGet {
-                    action: &form.action,
-                    fields: &fields,
-                },
-            )
-            .await?;
+            let url = fetch::build_query_url(&form.action, &fields)?;
+            self.run_idempotent("submit_form", form.action.clone(), &url)
+                .await?;
             return Ok(SubmitOutcome::Submitted);
         }
 
         // Confirmed non-GET: a single attempt, never silently retried.
+        self.begin_step();
         let result = match self.fetcher.submit(&form.action, method, &fields).await {
             Ok(r) => r,
             Err(e) => {
@@ -237,52 +226,26 @@ impl Session {
                 return Err(e);
             }
         };
-        let status = result.status;
-        if let Err(e) = self.record(result) {
-            self.log_attempt(
-                "submit_form",
-                &form.action,
-                Some(status),
-                1,
-                "distill_failed",
-                Some(short_err(&e)),
-            );
-            return Err(e);
-        }
-        let failure = self.last_snapshot.as_ref().and_then(planner::verify);
-        self.last_failure = failure.clone();
-        self.commit_navigation();
-        self.log_attempt(
-            "submit_form",
-            &form.action,
-            Some(status),
-            1,
-            outcome_label(&failure),
-            failure,
-        );
+        self.settle("submit_form", &form.action, 1, result)?;
         Ok(SubmitOutcome::Submitted)
     }
 
-    /// Run an idempotent step with verify + bounded retry. Only the result we
-    /// actually keep is recorded, so a discarded retryable attempt never advances
-    /// session state, and `redirect_history` gets one entry per settled
-    /// navigation.
-    async fn run_idempotent(
-        &mut self,
-        op: &str,
-        target: String,
-        step: Step<'_>,
-    ) -> Result<&Distilled> {
+    /// Run an idempotent step (a GET of `url`) with verify + bounded retry. Only
+    /// the result we actually keep is recorded, so a discarded retryable attempt
+    /// never advances session state, and `redirect_history` gets one entry per
+    /// settled navigation. Retries back off — honouring the server's
+    /// `Retry-After` when it sent one — so the loop never hammers a host that
+    /// just asked us to slow down.
+    async fn run_idempotent(&mut self, op: &str, target: String, url: &str) -> Result<&Distilled> {
+        self.begin_step();
         let mut attempt = 0usize;
         loop {
-            match self.do_fetch(&step).await {
-                Ok(result) => {
+            match self.fetcher.fetch_attempt(url).await {
+                Ok((result, retry_after)) => {
                     let status = result.status;
                     // Server said "try later" and we still have budget: discard
-                    // this response (don't advance state) and retry.
-                    if attempt < self.max_action_retries
-                        && crate::fetch::is_retryable_status(status)
-                    {
+                    // this response (don't advance state), back off, retry.
+                    if attempt < self.max_action_retries && fetch::is_retryable_status(status) {
                         self.log_attempt(
                             op,
                             &target,
@@ -291,40 +254,18 @@ impl Session {
                             "retryable_status",
                             Some(format!("http_status_{status}")),
                         );
+                        sleep(retry_after.unwrap_or_else(|| fetch::backoff_delay(attempt))).await;
                         attempt += 1;
                         continue;
                     }
-                    // Keep this result. record() is atomic: on a distill failure
-                    // it returns Err without mutating state.
-                    if let Err(e) = self.record(result) {
-                        self.log_attempt(
-                            op,
-                            &target,
-                            Some(status),
-                            attempt + 1,
-                            "distill_failed",
-                            Some(short_err(&e)),
-                        );
-                        return Err(e);
-                    }
-                    let failure = self.last_snapshot.as_ref().and_then(planner::verify);
-                    self.last_failure = failure.clone();
-                    self.commit_navigation();
-                    self.log_attempt(
-                        op,
-                        &target,
-                        Some(status),
-                        attempt + 1,
-                        outcome_label(&failure),
-                        failure,
-                    );
+                    // Keep this result.
+                    self.settle(op, &target, attempt + 1, result)?;
                     return self.snapshot_ref();
                 }
                 Err(e) => {
-                    // A transient transport error (the fetcher already exhausted
-                    // its own transport retries) gets one more whole-step try.
-                    let retry =
-                        attempt < self.max_action_retries && crate::fetch::is_transient_error(&e);
+                    // A transient transport error gets one more whole-step try
+                    // under the Action Loop budget.
+                    let retry = attempt < self.max_action_retries && fetch::is_transient_error(&e);
                     self.log_attempt(
                         op,
                         &target,
@@ -338,6 +279,7 @@ impl Session {
                         Some(short_err(&e)),
                     );
                     if retry {
+                        sleep(fetch::backoff_delay(attempt)).await;
                         attempt += 1;
                         continue;
                     }
@@ -347,15 +289,41 @@ impl Session {
         }
     }
 
-    /// Perform one fetch for a [`Step`]. Borrows only the client, so the caller
-    /// can mutate session state with the owned result afterwards.
-    async fn do_fetch(&self, step: &Step<'_>) -> Result<FetchResult> {
-        match step {
-            Step::Get(url) => self.fetcher.fetch(url).await,
-            Step::SubmitGet { action, fields } => {
-                self.fetcher.submit(action, SubmitMethod::Get, fields).await
-            }
+    /// Keep a settled fetch result: distill it into the snapshot (atomic — a
+    /// distill failure leaves prior state intact), verify it, commit the
+    /// navigation to history, and log the outcome. Shared by the idempotent
+    /// retry loop and the single-attempt confirmed non-GET submit.
+    fn settle(
+        &mut self,
+        op: &str,
+        target: &str,
+        attempt: usize,
+        result: FetchResult,
+    ) -> Result<()> {
+        let status = result.status;
+        if let Err(e) = self.record(result) {
+            self.log_attempt(
+                op,
+                target,
+                Some(status),
+                attempt,
+                "distill_failed",
+                Some(short_err(&e)),
+            );
+            return Err(e);
         }
+        let failure = self.last_snapshot.as_ref().and_then(planner::verify);
+        self.last_failure = failure.clone();
+        self.commit_navigation();
+        self.log_attempt(
+            op,
+            target,
+            Some(status),
+            attempt,
+            outcome_label(&failure),
+            failure,
+        );
+        Ok(())
     }
 
     /// Distill `result` into the current snapshot. Atomic: distills first, then
@@ -381,6 +349,13 @@ impl Session {
         }
     }
 
+    /// Start a new logical operation: every log entry it produces — including
+    /// discarded retry attempts — shares this step number, with `attempt`
+    /// telling them apart.
+    fn begin_step(&mut self) {
+        self.step += 1;
+    }
+
     fn log_attempt(
         &mut self,
         op: &str,
@@ -390,7 +365,6 @@ impl Session {
         outcome: &str,
         failure_reason: Option<String>,
     ) {
-        self.step += 1;
         self.log.push(OpLogEntry {
             step: self.step,
             op: op.to_string(),

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -258,3 +258,157 @@ async fn cookies_persist_across_requests() {
     assert_eq!(snap.status, 200, "cookie was not replayed");
     assert!(snap.markdown.contains("abc123"));
 }
+
+/// Options with transport retry OFF, so the Action-Loop's own verify+retry is the
+/// only thing that can recover a transient failure (isolates loop-level retry).
+fn opts_no_transport_retry() -> DistillOptions {
+    DistillOptions {
+        allow_local: true,
+        profile: rustbrowser::Profile::Full,
+        max_retries: 0,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn idempotent_get_retries_on_transient_5xx() {
+    let server = MockServer::start().await;
+    // First hit → 503 (transient); subsequent hits → 200 with real content.
+    Mock::given(method("GET"))
+        .and(path("/flaky"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("<html><body>busy</body></html>"))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/flaky"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string(
+                    "<html><body><h1>Recovered</h1><p>The flaky endpoint finally \
+                     returned its content.</p></body></html>",
+                ),
+        )
+        .with_priority(5)
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts_no_transport_retry()).unwrap();
+    let snap = s.observe(&format!("{}/flaky", server.uri())).await.unwrap();
+
+    // The loop discarded the 503 and kept the 200.
+    assert_eq!(snap.status, 200);
+    assert!(snap.markdown.contains("Recovered"));
+    // One settled navigation despite two HTTP attempts.
+    assert_eq!(s.redirect_history().len(), 1);
+    assert!(s.last_failure().is_none(), "final step verified clean");
+
+    // The log shows a discarded retryable attempt followed by an ok attempt.
+    let outcomes: Vec<&str> = s.log().iter().map(|e| e.outcome.as_str()).collect();
+    assert_eq!(outcomes, vec!["retryable_status", "ok"]);
+}
+
+#[tokio::test]
+async fn http_error_status_is_reported_but_not_retried() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/missing"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string("<html><body><h1>Not found</h1></body></html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts_no_transport_retry()).unwrap();
+    let snap = s
+        .observe(&format!("{}/missing", server.uri()))
+        .await
+        .unwrap();
+
+    assert_eq!(snap.status, 404);
+    // 4xx is a real failure surfaced to the planner, but not worth retrying.
+    assert_eq!(s.last_failure(), Some("http_status_404"));
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "a 4xx must not be auto-retried");
+    let outcomes: Vec<&str> = s.log().iter().map(|e| e.outcome.as_str()).collect();
+    assert_eq!(outcomes, vec!["verify_failed"]);
+}
+
+#[tokio::test]
+async fn dangerous_post_is_never_auto_retried() {
+    let server = MockServer::start().await;
+    home(&server).await;
+    // The login POST always fails with a 503. A retryable status on a non-GET
+    // submit must NOT trigger any retry — POST is non-idempotent.
+    Mock::given(method("POST"))
+        .and(path("/login"))
+        .respond_with(
+            ResponseTemplate::new(503)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string("<html><body><h1>Overloaded</h1></body></html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts_no_transport_retry()).unwrap();
+    s.observe(&format!("{}/", server.uri())).await.unwrap();
+    let values = [
+        ("user".to_string(), "alice".to_string()),
+        ("pass".to_string(), "secret".to_string()),
+    ];
+    let done = s.submit_form("form_1", &values, true).await.unwrap();
+    assert!(matches!(done, SubmitOutcome::Submitted));
+    assert_eq!(s.snapshot().unwrap().status, 503);
+    assert_eq!(s.last_failure(), Some("http_status_503"));
+
+    // Exactly one POST hit the server — no silent re-send.
+    let logins = server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == "/login")
+        .count();
+    assert_eq!(logins, 1, "POST submit must never be auto-retried");
+}
+
+#[tokio::test]
+async fn loop_view_exposes_state_actions_and_recommendation() {
+    let server = MockServer::start().await;
+    home(&server).await;
+
+    let mut s = Session::new(opts()).unwrap();
+    s.observe(&format!("{}/", server.uri())).await.unwrap();
+    let view = s.loop_view();
+
+    assert_eq!(view.state.status, 200);
+    assert!(view.failure_reason.is_none());
+    assert_eq!(view.state.action_count, 3); // 1 link + 2 forms
+
+    // The POST login form is flagged dangerous; the GET search form is not.
+    let login = view
+        .available_actions
+        .iter()
+        .find(|a| a.method.as_deref() == Some("POST"))
+        .expect("login form present");
+    assert!(login.dangerous);
+    assert!(login.fields.iter().any(|f| f == "user"));
+    let search = view
+        .available_actions
+        .iter()
+        .find(|a| a.method.as_deref() == Some("GET"))
+        .expect("search form present");
+    assert!(!search.dangerous);
+
+    // The GET search form is the recommended next action.
+    assert!(
+        view.recommended_next_actions
+            .iter()
+            .any(|r| r.action_id == search.action_id),
+        "search form should be recommended"
+    );
+}

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -259,16 +259,9 @@ async fn cookies_persist_across_requests() {
     assert!(snap.markdown.contains("abc123"));
 }
 
-/// Options with transport retry OFF, so the Action-Loop's own verify+retry is the
-/// only thing that can recover a transient failure (isolates loop-level retry).
-fn opts_no_transport_retry() -> DistillOptions {
-    DistillOptions {
-        allow_local: true,
-        profile: rustbrowser::Profile::Full,
-        max_retries: 0,
-        ..Default::default()
-    }
-}
+// Sessions structurally make one HTTP attempt per loop attempt (transport-level
+// retries are disabled inside `Session`), so the Action Loop's own verify+retry
+// is the only recovery path in all the tests below.
 
 #[tokio::test]
 async fn idempotent_get_retries_on_transient_5xx() {
@@ -295,7 +288,7 @@ async fn idempotent_get_retries_on_transient_5xx() {
         .mount(&server)
         .await;
 
-    let mut s = Session::new(opts_no_transport_retry()).unwrap();
+    let mut s = Session::new(opts()).unwrap();
     let snap = s.observe(&format!("{}/flaky", server.uri())).await.unwrap();
 
     // The loop discarded the 503 and kept the 200.
@@ -305,9 +298,39 @@ async fn idempotent_get_retries_on_transient_5xx() {
     assert_eq!(s.redirect_history().len(), 1);
     assert!(s.last_failure().is_none(), "final step verified clean");
 
-    // The log shows a discarded retryable attempt followed by an ok attempt.
+    // The log shows a discarded retryable attempt followed by an ok attempt —
+    // both belong to the same logical step, told apart by `attempt`.
     let outcomes: Vec<&str> = s.log().iter().map(|e| e.outcome.as_str()).collect();
     assert_eq!(outcomes, vec!["retryable_status", "ok"]);
+    let steps: Vec<(usize, usize)> = s.log().iter().map(|e| (e.step, e.attempt)).collect();
+    assert_eq!(steps, vec![(1, 1), (1, 2)]);
+    assert_eq!(s.loop_view().state.steps_taken, 1, "retries are not steps");
+}
+
+#[tokio::test]
+async fn action_retry_budget_maps_to_actual_http_attempts() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/busy"))
+        .respond_with(
+            ResponseTemplate::new(503)
+                .insert_header("Content-Type", "text/html")
+                .set_body_string("<html><body><h1>Still busy</h1></body></html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut s = Session::new(opts()).unwrap().with_max_action_retries(2);
+    let snap = s.observe(&format!("{}/busy", server.uri())).await.unwrap();
+
+    assert_eq!(snap.status, 503);
+    assert_eq!(s.last_failure(), Some("http_status_503"));
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        3,
+        "max_action_retries=2 should mean one original attempt plus two extra HTTP attempts"
+    );
 }
 
 #[tokio::test]
@@ -323,7 +346,7 @@ async fn http_error_status_is_reported_but_not_retried() {
         .mount(&server)
         .await;
 
-    let mut s = Session::new(opts_no_transport_retry()).unwrap();
+    let mut s = Session::new(opts()).unwrap();
     let snap = s
         .observe(&format!("{}/missing", server.uri()))
         .await
@@ -354,7 +377,7 @@ async fn dangerous_post_is_never_auto_retried() {
         .mount(&server)
         .await;
 
-    let mut s = Session::new(opts_no_transport_retry()).unwrap();
+    let mut s = Session::new(opts()).unwrap();
     s.observe(&format!("{}/", server.uri())).await.unwrap();
     let values = [
         ("user".to_string(), "alice".to_string()),
@@ -364,6 +387,8 @@ async fn dangerous_post_is_never_auto_retried() {
     assert!(matches!(done, SubmitOutcome::Submitted));
     assert_eq!(s.snapshot().unwrap().status, 503);
     assert_eq!(s.last_failure(), Some("http_status_503"));
+    // observe = step 1, the confirmed submit = step 2.
+    assert_eq!(s.loop_view().state.steps_taken, 2);
 
     // Exactly one POST hit the server — no silent re-send.
     let logins = server
@@ -397,6 +422,10 @@ async fn loop_view_exposes_state_actions_and_recommendation() {
         .expect("login form present");
     assert!(login.dangerous);
     assert!(login.fields.iter().any(|f| f == "user"));
+    assert!(
+        !login.fields.iter().any(|f| f == "csrf"),
+        "hidden defaults are carried internally but should not be suggested as fillable"
+    );
     let search = view
         .available_actions
         .iter()


### PR DESCRIPTION
## V1.3 — RB Action Loop

Browser Use 第三步:把 **Observe → Act → Verify** 收成一個可規劃的迴圈。建在 v1.2 的 session 之上。

### 新增
- **planner-friendly 回傳** — 每個 session 工具回傳新增 `loop` 物件:
  - `state`(url/status/title/excerpt + content_chars/action_count/low_content/used_headless/steps_taken)
  - `available_actions`(links/forms/buttons/downloads 攤平成統一形狀:`action_id`/`kind`/`label`/`target`/`method`/`fields`/`dangerous`)
  - `recommended_next_actions`(便宜誠實的啟發式提示,指向真實 `action_id`,**只是提示**)
  - `failure_reason`(該步驟未通過 verify 時才有)
- **Verify + 有限自動重試** — idempotent 步驟(observe/follow/GET 提交)抓後 verify;可重試的暫時性失敗(429/5xx 或暫時性連線錯誤)再試最多 `max_action_retries` 次(`session_start` 參數,預設 1、上限 2),維持 per-host rate limit。被丟棄的重試**不推進 session 狀態**。
- **操作 log** — 每 session 的 `operation_log`(step/op/target/status/attempt/outcome/failure_reason),供 debug。
- 函式庫新表面:`rustbrowser::planner`(`LoopView`/`PageState`/`AvailableAction`/`RecommendedAction`/`OpLogEntry`/`verify`)、`Session::loop_view`/`log`/`last_failure`/`with_max_action_retries`。

### 安全
- **高風險(非 GET)提交永不自動執行、永不自動重試** —— confirmation gate 不變,重試只套用在 idempotent 步驟。

### 相容性
- session view **純新增**:1.x 既有欄位(`session_id`/`current_url`/`redirect_history`/`snapshot`)不動,`loop` 與 `operation_log` 加在旁邊。schema freeze 守門測試已更新(`max_action_retries` 為新增參數)。

### 測試
- planner 單元測試(verify、flatten、recommend、空快照)
- session 整合測試(wiremock):`503→200` 觸發 loop 重試且只記一筆 history、`4xx` 回報但不重試、**POST 絕不自動重試**、`loop_view` 規劃格式
- 全套本機通過:fmt / clippy(-D warnings)/ test(lib + eval + integration + schema_freeze + session)

版本 1.2.0 → **1.3.0**。文件同步:CHANGELOG / README / docs/API.md / SECURITY.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)